### PR TITLE
Set order of file hash query to return the latest entry

### DIFF
--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -279,6 +279,7 @@ namespace roundhouse.databases
 
             DetachedCriteria crit = DetachedCriteria.For<ScriptsRun>()
                 .Add(Restrictions.Eq("script_name", script_name))
+                .AddOrder(Order.Desc("id"))
                 .SetMaxResults(1);
 
             try


### PR DESCRIPTION
Orders the results in get_current_script_hash() so that the most recent entry is returned.

The query in DefaultDatabase.cs was the only one I could find, if there are other implementations, let me know and I will update those as well.
