### PR TITLE
Allow disabling of script output (backups, scripts), log files are retained

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -245,6 +245,12 @@
                          "OutputPath - This is where everything related to the migration is stored. This includes any backups, all items that ran, permission dumps, logs, etc. Defaults to \"{0}\".",
                          ApplicationParameters.default_output_path),
                      option => configuration.OutputPath = option)
+                //output
+                .Add("disableoutput",
+                     string.Format(
+                         "DisableoOutput - Disable output of backups, items ran, permissions dumps, etc. Log files are kept. Useful for example in CI environment. Defaults to \"{0}\".",
+                         ApplicationParameters.default_disable_output),
+                     option => configuration.DisableOutput = option != null)
                 //warn on changes
                 .Add("w|warnononetimescriptchanges",
                      "WarnOnOneTimeScriptChanges - If you do not want RH to error when you change scripts that should not change, you must set this flag. One time scripts are DDL/DML (anything in the upFolder). Defaults to false.",

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -130,6 +130,8 @@
 
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
 
+        public bool DisableOutput { get; set; }
+
         #endregion
 
         public void run_the_task()

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -55,5 +55,6 @@ namespace roundhouse.consoles
         public bool RunAllAnyTimeScripts { get; set; }
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
+        public bool DisableOutput { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -55,5 +55,6 @@ namespace roundhouse.infrastructure.app
         bool RunAllAnyTimeScripts { get; set; }
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
+        bool DisableOutput { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure/ApplicationParameters.cs
+++ b/product/roundhouse/infrastructure/ApplicationParameters.cs
@@ -40,6 +40,7 @@ namespace roundhouse.infrastructure
         public static readonly int default_command_timeout = 60;
         public static readonly int default_admin_command_timeout = 300;
         public static readonly int default_restore_timeout = 900;
+        public static readonly bool default_disable_output = false;
 
         public static string get_merged_assembly_name()
         {

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -305,11 +305,14 @@ namespace roundhouse.runners
 
         private void copy_to_change_drop_folder(string sql_file_ran, Folder migration_folder)
         {
-            string destination_file = file_system.combine_paths(known_folders.change_drop.folder_full_path, "itemsRan",
-                                                                sql_file_ran.Replace(migration_folder.folder_path + "\\", string.Empty));
-            file_system.verify_or_create_directory(file_system.get_directory_name_from(destination_file));
-            Log.bound_to(this).log_a_debug_event_containing("Copying file {0} to {1}.", file_system.get_file_name_from(sql_file_ran), destination_file);
-            file_system.file_copy_unsafe(sql_file_ran, destination_file, true);
+            if (!configuration.DisableOutput)
+            {
+                string destination_file = file_system.combine_paths(known_folders.change_drop.folder_full_path, "itemsRan",
+                                                                    sql_file_ran.Replace(migration_folder.folder_path + "\\", string.Empty));
+                file_system.verify_or_create_directory(file_system.get_directory_name_from(destination_file));
+                Log.bound_to(this).log_a_debug_event_containing("Copying file {0} to {1}.", file_system.get_file_name_from(sql_file_ran), destination_file);
+                file_system.file_copy_unsafe(sql_file_ran, destination_file, true);
+            }
         }
     }
 }


### PR DESCRIPTION
In CI environments drop-create with large test data can create quite much output. It's easier to have an option to disable scripts ran output in this scenario.
