### PR TITLE
Added text file version resolver.

### DIFF
--- a/product/roundhouse/infrastructure.app/builders/VersionResolverBuilder.cs
+++ b/product/roundhouse/infrastructure.app/builders/VersionResolverBuilder.cs
@@ -10,9 +10,10 @@ namespace roundhouse.infrastructure.app.builders
         {
             VersionResolver xml_version_finder = new XmlFileVersionResolver(file_system, configuration_property_holder.VersionXPath, configuration_property_holder.VersionFile);
             VersionResolver dll_version_finder = new DllFileVersionResolver(file_system, configuration_property_holder.VersionFile);
+            VersionResolver text_version_finder = new TextVersionResolver(file_system, configuration_property_holder.VersionFile);
             VersionResolver script_number_version_finder = new ScriptfileVersionResolver(file_system, configuration_property_holder);
-            
-            IEnumerable<VersionResolver> resolvers = new List<VersionResolver> { xml_version_finder, dll_version_finder, script_number_version_finder };
+
+            IEnumerable<VersionResolver> resolvers = new List<VersionResolver> { xml_version_finder, dll_version_finder, text_version_finder, script_number_version_finder };
 
             return new ComplexVersionResolver(resolvers);
         }

--- a/product/roundhouse/resolvers/TextVersionResolver.cs
+++ b/product/roundhouse/resolvers/TextVersionResolver.cs
@@ -1,0 +1,52 @@
+using System;
+
+using roundhouse.infrastructure.filesystem;
+using roundhouse.infrastructure.logging;
+
+namespace roundhouse.resolvers
+{
+    public class TextVersionResolver : VersionResolver
+    {
+        private readonly FileSystemAccess file_system;
+        private readonly string version_file;
+
+        public TextVersionResolver(FileSystemAccess file_system, string version_file)
+        {
+            this.file_system = file_system;
+            this.version_file = version_file;
+        }
+
+        public bool meets_criteria()
+        {
+            return version_file.EndsWith(".txt", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public string resolve_version()
+        {
+            Log.bound_to(this).log_an_info_event_containing(
+                " Attempting to resolve version from text file {0}.", version_file);
+
+            string version = "0";
+            if (file_system.file_exists(version_file))
+            {
+                try
+                {
+                    version = file_system.read_file_text(version_file);
+                    Log.bound_to(this).log_an_info_event_containing(" Found version {0} from {1}.", version, version_file);
+                }
+                catch (Exception e)
+                {
+                    Log.bound_to(this).log_an_error_event_containing(
+                        "Unable to get version from text file {0}:{1}{2}", version_file, Environment.NewLine, e.Message);
+                }
+            }
+            else
+            {
+                Log.bound_to(this).log_a_warning_event_containing(
+                    "Unable to get version from text file {0}. File doesn't exist.", version_file);
+            }
+
+            return version;
+        }
+    }
+}

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -132,6 +132,7 @@
     <Compile Include="parameters\IParameter.cs" />
     <Compile Include="Migrate.cs" />
     <Compile Include="resolvers\ScriptfileVersionResolver.cs" />
+    <Compile Include="resolvers\TextVersionResolver.cs" />
     <Compile Include="RoundhousEFluentNHibernateDiffingType.cs" />
     <Compile Include="RoundhouseMode.cs" />
     <Compile Include="runners\RoundhouseNHibernateCompareRunner.cs" />


### PR DESCRIPTION
When the version file passed into Roundhouse has a .txt file extension, TextVersionResolver will simply use the contents of the file as the version.
