### PR TITLE
Configurable Execution Workflow

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -122,7 +122,7 @@
                      option => configuration.DatabaseType = option)
                 // versioning
                 .Add("wfc=|workflowconfig=|workflowconfigfile=",
-                    "WorkflowConfigFile - Custom configuration file listing the folders to execute and the order of execution.",
+                    "WorkflowConfigFile - Custom configuration file listing the folders to execute and the order of execution. Expected format: Friendly Name, Folder Name, Timing. Timing can be 'anytime', 'onetime' or 'everytime'.",
                     option => configuration.WorkflowConfigFile = option)
                 .Add("r=|repo=|repositorypath=",
                      string.Format(
@@ -319,6 +319,7 @@
                         "/c[onnection]s[tring]a[dministration] VALUE " +
                         "/c[ommand]t[imeout] VALUE /c[ommand]t[imeout]a[dmin] VALUE " +
                         "/r[epositorypath] VALUE /v[ersion]f[ile] VALUE /v[ersion]x[path] VALUE " +
+                        "/w[ork]f[low]c[onfig] VALUE " +
                         "/a[lter]d[atabasefoldername] /r[un]a[fter]c[reate]d[atabasefoldername] VALUE VALUE /u[pfoldername] VALUE /do[wnfoldername] VALUE " +
                         "/r[un]f[irstafterupdatefoldername] VALUE /fu[nctionsfoldername] VALUE /v[ie]w[sfoldername] VALUE " +
                         "/sp[rocsfoldername] VALUE /i[nde]x[foldername] VALUE /p[ermissionsfoldername] VALUE " +

--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -19,7 +19,7 @@
     using migrators;
     using resolvers;
     using runners;
-    using roundhouse.workflow;
+    using workflow;
 
     public class Program
     {

--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -19,6 +19,7 @@
     using migrators;
     using resolvers;
     using runners;
+    using roundhouse.workflow;
 
     public class Program
     {
@@ -412,6 +413,7 @@
                 Container.get_an_instance_of<FileSystemAccess>(),
                 Container.get_an_instance_of<DatabaseMigrator>(),
                 Container.get_an_instance_of<VersionResolver>(),
+                Container.get_an_instance_of<WorkflowProvider>(),
                 configuration.Silent,
                 configuration.Drop,
                 configuration.DoNotCreateDatabase,

--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -121,6 +121,9 @@
                          ApplicationParameters.default_database_type),
                      option => configuration.DatabaseType = option)
                 // versioning
+                .Add("wfc=|workflowconfig=|workflowconfigfile=",
+                    "WorkflowConfigFile - Custom configuration file listing the folders to execute and the order of execution.",
+                    option => configuration.WorkflowConfigFile = option)
                 .Add("r=|repo=|repositorypath=",
                      string.Format(
                          "RepositoryPath - The repository. A string that can be anything. Used to track versioning along with the version. Defaults to null."),

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -13,7 +13,7 @@
     using resolvers;
     using runners;
     using Environment = environments.Environment;
-    using roundhouse.workflow;
+    using workflow;
 
     public sealed class Roundhouse : ITask, ConfigurationPropertyHolder
     {

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -13,6 +13,7 @@
     using resolvers;
     using runners;
     using Environment = environments.Environment;
+    using roundhouse.workflow;
 
     public sealed class Roundhouse : ITask, ConfigurationPropertyHolder
     {
@@ -132,6 +133,7 @@
 
         public bool DisableOutput { get; set; }
 
+        public string WorkflowConfigFile { get; set; }
         #endregion
 
         public void run_the_task()
@@ -155,6 +157,7 @@
                 Container.get_an_instance_of<FileSystemAccess>(),
                 Container.get_an_instance_of<DatabaseMigrator>(),
                 Container.get_an_instance_of<VersionResolver>(),
+                Container.get_an_instance_of<WorkflowProvider>(),
                 Silent,
                 Drop,
                 DoNotCreateDatabase,

--- a/product/roundhouse/Migrate.cs
+++ b/product/roundhouse/Migrate.cs
@@ -13,7 +13,7 @@ namespace roundhouse
     using resolvers;
     using runners;
     using Environment = roundhouse.environments.Environment;
-    using roundhouse.workflow;
+    using workflow;
 
     public class Migrate
     {
@@ -65,7 +65,7 @@ namespace roundhouse
                Container.get_an_instance_of<FileSystemAccess>(),
                Container.get_an_instance_of<DatabaseMigrator>(),
                Container.get_an_instance_of<VersionResolver>(),
-                Container.get_an_instance_of<WorkflowProvider>(),
+               Container.get_an_instance_of<WorkflowProvider>(),
                configuration.Silent,
                configuration.Drop,
                configuration.DoNotCreateDatabase,

--- a/product/roundhouse/Migrate.cs
+++ b/product/roundhouse/Migrate.cs
@@ -13,6 +13,7 @@ namespace roundhouse
     using resolvers;
     using runners;
     using Environment = roundhouse.environments.Environment;
+    using roundhouse.workflow;
 
     public class Migrate
     {
@@ -64,6 +65,7 @@ namespace roundhouse
                Container.get_an_instance_of<FileSystemAccess>(),
                Container.get_an_instance_of<DatabaseMigrator>(),
                Container.get_an_instance_of<VersionResolver>(),
+                Container.get_an_instance_of<WorkflowProvider>(),
                configuration.Silent,
                configuration.Drop,
                configuration.DoNotCreateDatabase,

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -56,5 +56,6 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
+        public string WorkflowConfigFile { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -56,5 +56,6 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
+        string WorkflowConfigFile { get; set; }
     }
 }

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -190,6 +190,7 @@
     <Compile Include="migrators\DatabaseMigrator.cs" />
     <Compile Include="migrators\DefaultDatabaseMigrator.cs" />
     <Compile Include="databases\SqlServerLiteSpeedDatabase.cs" />
+    <Compile Include="workflow\WorkflowProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="infrastructure.app\logging\log4net.config.xml" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -12,7 +12,7 @@ namespace roundhouse.runners
     using migrators;
     using resolvers;
     using Environment = environments.Environment;
-    using roundhouse.workflow;
+    using workflow;
 
     public sealed class RoundhouseMigrationRunner : IRunner
     {
@@ -29,7 +29,7 @@ namespace roundhouse.runners
         private readonly bool use_simple_recovery;
         private readonly ConfigurationPropertyHolder configuration;
         private const string SQL_EXTENSION = "*.sql";
-        private WorkflowProvider workflow_provider;
+        private readonly WorkflowProvider workflow_provider;
 
         public RoundhouseMigrationRunner(
             string repository_path,

--- a/product/roundhouse/workflow/WorkflowProvider.cs
+++ b/product/roundhouse/workflow/WorkflowProvider.cs
@@ -4,21 +4,26 @@ using System.Linq;
 using System.Text;
 using roundhouse.infrastructure.app;
 using roundhouse.folders;
+using roundhouse.infrastructure.logging;
+using roundhouse.infrastructure.filesystem;
+using System.IO;
 
 namespace roundhouse.workflow
 {
     public class WorkflowProvider
     {
-        public WorkflowProvider(ConfigurationPropertyHolder configuration, KnownFolders knownFolders)
+        public WorkflowProvider(ConfigurationPropertyHolder configuration, KnownFolders knownFolders, FileSystemAccess fileSystem)
         {
             _configuration = configuration;
             _knownFolders = knownFolders;
+            _fileSystem = fileSystem;
         }
 
         public IEnumerable<MigrationsFolder> GetFolders()
         {
             if (string.IsNullOrEmpty(_configuration.WorkflowConfigFile))
             {
+                Log.bound_to(this).log_an_info_event_containing("Using default RoundhousE workflow.");
                 return new[] {
                     _knownFolders.up,
                     _knownFolders.run_first_after_up,
@@ -29,10 +34,89 @@ namespace roundhouse.workflow
                     _knownFolders.run_after_other_any_time_scripts
                };
             }
-            return new MigrationsFolder[0];
+            else
+            {
+                Log.bound_to(this).log_an_info_event_containing("Using custom workflow from configuration file {0}.", _configuration.WorkflowConfigFile);
+                return LoadFromConfigFile(_configuration.WorkflowConfigFile);
+            }
+        }
+
+        private IEnumerable<MigrationsFolder> LoadFromConfigFile(string configFile)
+        {
+            var lineNum = 0;
+            var folders = new List<MigrationsFolder>();
+            using (var stream = LoadConfigFile(configFile))
+            using (var reader = new StreamReader(stream))
+            while (true)
+            {
+                var line = reader.ReadLine();
+                if (line == null)
+                    break;
+                if (line.Trim() == string.Empty)
+                    continue;
+
+                lineNum++;
+                var folder = ParseLineIntoFolder(line, lineNum);
+                folders.Add(folder);
+            }
+            return folders;
+        }
+
+        private FileStream LoadConfigFile(string configFile)
+        {
+            if (_fileSystem.file_exists(configFile) == false)
+            {
+                throw new ArgumentException(string.Format(
+                    "Custom workflow configuration file {0} does not exist.", configFile));
+            }
+
+            try
+            {
+                return _fileSystem.open_file_in_read_mode_from(configFile);
+            }
+            catch (IOException e)
+            {
+                throw new IOException(string.Format(
+                    "Unable to read custom workflow configuration file {0}.", configFile), e);
+            }
+        }
+
+        private MigrationsFolder ParseLineIntoFolder(string line, int lineNum)
+        {
+            var options = line.Split(',').Select(option => option.Trim()).ToArray();
+            if (options.Length != 3)
+            {
+                throw new ArgumentException(string.Format(
+                    "Workflow configuration file: line {0} is invalid. " +
+                    "Expected the following format: Friendly Name, Folder Name, Timing", lineNum));
+            }
+            var friendly = options[0];
+            var foldername = options[1];
+            var timing = options[2].ToLowerInvariant();
+            switch(timing)
+            {
+                case "onetime": 
+                    return new DefaultMigrationsFolder(_fileSystem, 
+                        _configuration.SqlFilesDirectory,
+                        foldername, true, false, friendly);
+                case "anytime":
+                    return new DefaultMigrationsFolder(_fileSystem, 
+                        _configuration.SqlFilesDirectory,
+                        foldername, false, false, friendly);
+                case "everytime":
+                    return new DefaultMigrationsFolder(_fileSystem, 
+                        _configuration.SqlFilesDirectory,
+                        foldername, false, true, friendly);
+                default:
+                    throw new ArgumentException(string.Format(
+                        "Workflow configuration file: line {0} is invalid. " +
+                        "Expected timing to be onetime, anytime, or everytime. " +
+                        "Instead received {1}.", lineNum, timing));
+            }
         }
 
         private readonly ConfigurationPropertyHolder _configuration;
         private readonly KnownFolders _knownFolders;
+        private readonly FileSystemAccess _fileSystem;
     }
 }

--- a/product/roundhouse/workflow/WorkflowProvider.cs
+++ b/product/roundhouse/workflow/WorkflowProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using roundhouse.infrastructure.app;
 using roundhouse.folders;
 using roundhouse.infrastructure.logging;

--- a/product/roundhouse/workflow/WorkflowProvider.cs
+++ b/product/roundhouse/workflow/WorkflowProvider.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using roundhouse.infrastructure.app;
+using roundhouse.folders;
+
+namespace roundhouse.workflow
+{
+    public class WorkflowProvider
+    {
+        public WorkflowProvider(ConfigurationPropertyHolder configuration, KnownFolders knownFolders)
+        {
+            _configuration = configuration;
+            _knownFolders = knownFolders;
+        }
+
+        public IEnumerable<MigrationsFolder> GetFolders()
+        {
+            if (string.IsNullOrEmpty(_configuration.WorkflowConfigFile))
+            {
+                return new[] {
+                    _knownFolders.up,
+                    _knownFolders.run_first_after_up,
+                    _knownFolders.functions,
+                    _knownFolders.views,
+                    _knownFolders.sprocs,
+                    _knownFolders.indexes,
+                    _knownFolders.run_after_other_any_time_scripts
+               };
+            }
+            return new MigrationsFolder[0];
+        }
+
+        private readonly ConfigurationPropertyHolder _configuration;
+        private readonly KnownFolders _knownFolders;
+    }
+}


### PR DESCRIPTION
Our database deployment workflow doesn't quite fit into the default workflow provided by Roundhouse. This pull request adds the ability to customize which folders are executed and when.

A new optional configuration setting (WorkflowConfigFile) allows one to point Roundhouse at a CSV file containing the desired workflow. Here is sample of what the config file would look like for the roundhouse default workflow:

Update, up, onetime
Run First After Update, runFirstAfterUp, onetime
Function, functions, anytime
View, views, anytime
Stored Procedure, sprocs, anytime
Index, indexes, anytime
Run after Other Anytime Scripts, runAfterOtherAnyTimeScripts, anytime
