### PR TITLE
Changed exception logging to include exception details/stacktrace

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -48,7 +48,7 @@
             }
             catch (Exception ex)
             {
-                the_logger.Info(ex.Message);
+                the_logger.Error(ex.Message, ex);
                 Environment.Exit(1);
             }
         }


### PR DESCRIPTION
Changed the way exceptions are logged, was struggling with rh.exe failing with only this output: 

"The type initializer for 'StructureMap.StructureMapConfiguration' threw an exception." 

No details of the internal exception or stacktrace is shown, this made this problem hard to find. After switching to using Log4nets Error method (ex.Message, ex) the message AND internal exception message/stack trace is printed to the console/output making this problem easy to identity (caused by .NET framework 3.5 was not installed on buildserver).  
