### PR TITLE
Fix for a breaking change with NH3.3

### DIFF
--- a/product/roundhouse.databases.sqlserver2000/orm/ScriptsRunMapping.cs
+++ b/product/roundhouse.databases.sqlserver2000/orm/ScriptsRunMapping.cs
@@ -19,7 +19,7 @@ namespace roundhouse.databases.sqlserver2000.orm
             Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
             Map(x => x.version_id);
             Map(x => x.script_name);
-            Map(x => x.text_of_script).CustomSqlType("text");
+            Map(x => x.text_of_script).CustomType("StringClob").CustomSqlType("text");
             Map(x => x.text_hash).Length(512);
             Map(x => x.one_time_script);
 


### PR DESCRIPTION
 The mapping for text_of_script for SqlServer set the custom sql type, but not the type in NHibernate. This caused scripts to be silently truncated to 4000 characters <NH 3.3. However, NH3.3 now throws an exception instead of silently truncating, causing roundhouse to fail.
