### PR TITLE
Implemented --isuptodate switch

### DIFF
--- a/product/roundhouse/migrators/DatabaseMigrator.cs
+++ b/product/roundhouse/migrators/DatabaseMigrator.cs
@@ -23,5 +23,6 @@ namespace roundhouse.migrators
         long version_the_database(string repository_path, string repository_version);
         bool run_sql(string sql_to_run, string script_name, bool run_this_script_once, bool run_this_script_every_time, long version_id, Environment migrating_environment, string repository_version, string repository_path, ConnectionType connection_type);
         //void transfer_to_database_for_changes();
+        bool this_script_is_new_or_updated(string script_name, string sql_to_run, Environment environment);
     }
 }

--- a/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
+++ b/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
@@ -321,6 +321,18 @@ namespace roundhouse.migrators
             return true;
         }
 
+        public bool this_script_is_new_or_updated(string script_name, string sql_to_run, Environment environment)
+        {
+            if (!this_is_an_environment_file_and_its_in_the_right_environment(script_name, environment))
+                return false;
+
+            if (this_script_has_run_already(script_name)
+                   && !this_script_has_changed_since_last_run(script_name, sql_to_run))
+                return false;
+
+            return true;
+        }
+
         public bool this_is_an_environment_file_and_its_in_the_right_environment(string script_name, Environment environment)
         {
             Log.bound_to(this).log_a_debug_event_containing("Checking to see if {0} is an environment file. We are in the {1} environment.", script_name, environment.name);

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -137,6 +137,7 @@
     <Compile Include="RoundhouseMode.cs" />
     <Compile Include="runners\RoundhouseNHibernateCompareRunner.cs" />
     <Compile Include="runners\RoundhouseRedGateCompareRunner.cs" />
+    <Compile Include="runners\RoundhouseUpdateCheckRunner.cs" />
     <Compile Include="sqlsplitters\StatementSplitter.cs" />
     <Compile Include="consoles\DefaultConfiguration.cs" />
     <Compile Include="cryptography\CryptographicService.cs" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -293,7 +293,7 @@ namespace roundhouse.runners
             return file_system.read_file_text(file_location);
         }
 
-        private string replace_tokens(string sql_text)
+        public string replace_tokens(string sql_text)
         {
             if (configuration.DisableTokenReplacement)
             {

--- a/product/roundhouse/runners/RoundhouseUpdateCheckRunner.cs
+++ b/product/roundhouse/runners/RoundhouseUpdateCheckRunner.cs
@@ -1,0 +1,90 @@
+using System;
+
+using roundhouse.folders;
+using roundhouse.infrastructure.app;
+using roundhouse.infrastructure.filesystem;
+using roundhouse.infrastructure.logging;
+using roundhouse.migrators;
+using Environment = roundhouse.environments.Environment;
+
+namespace roundhouse.runners
+{
+    public class RoundhouseUpdateCheckRunner : IRunner
+    {
+        private readonly ConfigurationPropertyHolder configuration;
+        private readonly Environment environment;
+        private readonly KnownFolders known_folders;
+        private readonly FileSystemAccess file_system;
+        private readonly DatabaseMigrator database_migrator;
+        private readonly RoundhouseMigrationRunner migration_runner;
+
+        private const string SQL_EXTENSION = "*.sql";
+
+
+        public RoundhouseUpdateCheckRunner(
+            Environment environment,
+            KnownFolders known_folders, 
+            FileSystemAccess file_system, 
+            DatabaseMigrator database_migrator, 
+            ConfigurationPropertyHolder configuration,
+            RoundhouseMigrationRunner migration_runner)
+        {
+            this.environment = environment;
+            this.known_folders = known_folders;
+            this.file_system = file_system;
+            this.database_migrator = database_migrator;
+            this.configuration = configuration;
+            this.migration_runner = migration_runner;
+        }
+
+
+        public void run()
+        {
+            database_migrator.open_connection(false);
+
+            // TODO: Consider if we should just return false if the roundhouse tables does not exist, instead of creating them.
+            database_migrator.run_roundhouse_support_tasks();
+
+            bool is_up_to_date = is_database_up_to_date();
+
+            // Info and warn level logging is turned off, in order to make it easy to use the output of this command.
+            // This message can therefore not be printed using the info logging as used by most other output in roundhouse.
+            Console.WriteLine("Database is up to date: {0}", is_up_to_date);
+        }
+
+
+        public bool is_database_up_to_date()
+        {
+            return check_folder(known_folders.alter_database)
+                && check_folder(known_folders.up)
+                && check_folder(known_folders.run_first_after_up)
+                && check_folder(known_folders.functions)
+                && check_folder(known_folders.views)
+                && check_folder(known_folders.sprocs)
+                && check_folder(known_folders.indexes)
+                && check_folder(known_folders.run_after_other_any_time_scripts)
+                && check_folder(known_folders.permissions);
+        }
+
+        private bool check_folder(MigrationsFolder migration_folder)
+        {
+            if (!file_system.directory_exists(migration_folder.folder_full_path)) return true;
+
+            var file_names = file_system.get_all_file_name_strings_recurevly_in(migration_folder.folder_full_path, SQL_EXTENSION);
+            foreach (string sql_file in file_names)
+            {
+                string sql_file_text = migration_runner.replace_tokens(migration_runner.get_file_text(sql_file));
+
+                bool script_should_run = database_migrator.this_script_is_new_or_updated(
+                    file_system.get_file_name_from(sql_file),
+                    sql_file_text,
+                    environment);
+
+                if (script_should_run)
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/product/roundhouse/runners/RoundhouseUpdateCheckRunner.cs
+++ b/product/roundhouse/runners/RoundhouseUpdateCheckRunner.cs
@@ -40,11 +40,6 @@ namespace roundhouse.runners
 
         public void run()
         {
-            database_migrator.open_connection(false);
-
-            // TODO: Consider if we should just return false if the roundhouse tables does not exist, instead of creating them.
-            database_migrator.run_roundhouse_support_tasks();
-
             bool is_up_to_date = is_database_up_to_date();
 
             // Info and warn level logging is turned off, in order to make it easy to use the output of this command.
@@ -55,15 +50,24 @@ namespace roundhouse.runners
 
         public bool is_database_up_to_date()
         {
-            return check_folder(known_folders.alter_database)
-                && check_folder(known_folders.up)
-                && check_folder(known_folders.run_first_after_up)
-                && check_folder(known_folders.functions)
-                && check_folder(known_folders.views)
-                && check_folder(known_folders.sprocs)
-                && check_folder(known_folders.indexes)
-                && check_folder(known_folders.run_after_other_any_time_scripts)
-                && check_folder(known_folders.permissions);
+            database_migrator.open_connection(false);
+
+            // TODO: Consider if we should just return false if the roundhouse tables does not exist, instead of creating them.
+            database_migrator.run_roundhouse_support_tasks();
+
+            bool up_to_date = check_folder(this.known_folders.alter_database)
+                                      && check_folder(this.known_folders.up)
+                                      && check_folder(this.known_folders.run_first_after_up)
+                                      && check_folder(this.known_folders.functions)
+                                      && check_folder(this.known_folders.views)
+                                      && check_folder(this.known_folders.sprocs)
+                                      && check_folder(this.known_folders.indexes)
+                                      && check_folder(this.known_folders.run_after_other_any_time_scripts)
+                                      && check_folder(this.known_folders.permissions);
+
+            database_migrator.close_connection();
+
+            return up_to_date;
         }
 
         private bool check_folder(MigrationsFolder migration_folder)


### PR DESCRIPTION
In our automated deployment scenario for a web application on load balanced web servers, we need to know if there are any changes to the database before running roundhouse. When there are db changes, we need to take take the application offline before updating. When there are only changes to the web app code, we can pull each server out of load balancer, update, and push it back in without any downtime.

To support this scenario, I have implemented the --isuptodate switch. It will simply tell if there are any db changes or not, in a way that is easy to interpret in a script. When combined with the --silent switch, the output is simply "Database is up to date: True" or "Database is up to date: False".
