### PR TITLE
Preserve token case for unmatched tokens.

### DIFF
--- a/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
@@ -74,9 +74,9 @@ namespace roundhouse.tests.infrastructure.app.tokens
             }
 
             [Observation]
-            public void if_given_a_value_that_does_not_exist_should_return_the_value()
+            public void if_given_a_value_that_does_not_exist_should_return_the_value_with_original_casing()
             {
-                TokenReplacer.replace_tokens(configuration, "ALTER DATABASE {{database}}").should_be_equal_to("ALTER DATABASE {{database}}");
+                TokenReplacer.replace_tokens(configuration, "ALTER DATABASE {{DataBase}}").should_be_equal_to("ALTER DATABASE {{DataBase}}");
             }
         }
     }

--- a/product/roundhouse/infrastructure.app/tokens/TokenReplacer.cs
+++ b/product/roundhouse/infrastructure.app/tokens/TokenReplacer.cs
@@ -18,7 +18,7 @@ namespace roundhouse.infrastructure.app.tokens
             {
                 string key = "";
 
-                key = m.Groups["key"].Value.to_lower();
+                key = m.Groups["key"].Value;
                 if (!dictionary.ContainsKey(key))
                 {
                     return "{{" + key + "}}";
@@ -33,10 +33,10 @@ namespace roundhouse.infrastructure.app.tokens
 
         private static IDictionary<string, string> create_dictionary_from_configuration(ConfigurationPropertyHolder configuration)
         {
-            Dictionary<string, string> property_dictionary = new Dictionary<string, string>();
+            Dictionary<string, string> property_dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var property in configuration.GetType().GetProperties())
             {
-                property_dictionary.Add(property.Name.to_lower(), property.GetValue(configuration, null).to_string());
+                property_dictionary.Add(property.Name, property.GetValue(configuration, null).to_string());
             }
 
             return property_dictionary;


### PR DESCRIPTION
When the token syntax is used but a token is not found in the token dictionary, preserve the case used in the original text. This is being accomplished using a case insensitive dictionary for comparisons instead of to_lower.
