### PR TITLE
Fix to Issue #69 - problem with logging FluentNhibernate messages when calling the roundhouse library directly

### DIFF
--- a/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
+++ b/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
@@ -76,7 +76,8 @@ namespace roundhouse.infrastructure.persistence
             }
             catch (Exception ex)
             {
-                Log.bound_to(this).log_a_warning_event_containing("Had an error building session factory from merged, attempting unmerged. The error:{0}{1}",System.Environment.NewLine,ex.ToString());
+                // Changed from warning to debug. I may not be using session factory and this warning just adds noise.
+                Log.bound_to(this).log_a_debug_event_containing("Had an error building session factory from merged, attempting unmerged. The error:{0}{1}",System.Environment.NewLine,ex.ToString());
                 return build_session_factory(func_dictionary[configuration_holder.DatabaseType](), DefaultAssemblyLoader.load_assembly(assembly_name),
                                              top_namespace, additional_function);
             }


### PR DESCRIPTION
referencing roundhouse dll directly (instead of just running rh.exe) generates constant fluentNhibernate resolution warnings in the log, even with simple deploys

Changed warning message to a debug event. This message constantly logs a warning in standard output even when not actually using fluent NHibernate and you are running database upgrades by referencing roundhouse library directly.
