### PR TITLE
Change Migration Runner to use relative file path

### DIFF
--- a/product/roundhouse/infrastructure/filesystem/FileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/FileSystemAccess.cs
@@ -1,6 +1,7 @@
 namespace roundhouse.infrastructure.filesystem
 {
     using System.IO;
+using roundhouse.folders;
 
     /// <summary>
     /// Handles all access to the file system objects
@@ -95,6 +96,14 @@ namespace roundhouse.infrastructure.filesystem
         /// <param name="file_path">File to analyze</param>
         /// <returns>The oldest date on the file</returns>
         string get_file_date(string file_path);
+
+        /// <summary>
+        /// Determines the file name from the filepath
+        /// </summary>
+        /// <param name="file_path">Full path to file including file name</param>
+        /// <param name="containingFolder">The folder containing this file.</param>
+        /// <returns>Returns only the file name from the filepath</returns>
+        string get_file_name_from(string file_path, Folder containingFolder);
 
         /// <summary>
         /// Determines the file name from the filepath

--- a/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
@@ -9,6 +9,7 @@ namespace roundhouse.infrastructure.filesystem
     using System.Runtime.InteropServices;
     using logging;
     using extensions;
+    using roundhouse.folders;
 
     /// <summary>
     /// All file system access code comes through here
@@ -209,12 +210,28 @@ namespace roundhouse.infrastructure.filesystem
         /// Determines the file name from the filepath
         /// </summary>
         /// <param name="file_path">Full path to file including file name</param>
+        /// <param name="containingFolder">The folder containing this file.</param>
+        /// <returns>Returns only the file name from the filepath</returns>
+        public string get_file_name_from(string file_path, Folder containingFolder)
+        {
+            if(!file_path.StartsWith(containingFolder.folder_full_path))
+            {
+                throw new Exception("Something bad has happened!");
+            }
+
+            // we want to return the relative path to the file.
+            return file_path.Substring(containingFolder.folder_full_path.Length).TrimStart(Path.DirectorySeparatorChar);
+        }
+
+        /// <summary>
+        /// Determines the file name from the filepath
+        /// </summary>
+        /// <param name="file_path">Full path to file including file name</param>
         /// <returns>Returns only the file name from the filepath</returns>
         public string get_file_name_from(string file_path)
         {
             return Path.GetFileName(file_path);
         }
-
         /// <summary>
         /// Determines the file name from the filepath without the extension
         /// </summary>

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -263,7 +263,7 @@ namespace roundhouse.runners
             {
                 string sql_file_text = replace_tokens(get_file_text(sql_file));
                 Log.bound_to(this).log_a_debug_event_containing(" Found and running {0}.", sql_file);
-                bool the_sql_ran = database_migrator.run_sql(sql_file_text, file_system.get_file_name_from(sql_file),
+                bool the_sql_ran = database_migrator.run_sql(sql_file_text, file_system.get_file_name_from(sql_file, migration_folder),
                                                              migration_folder.should_run_items_in_folder_once,
                                                              migration_folder.should_run_items_in_folder_every_time,
                                                              version_id, migrating_environment, repository_version, repository_path, connection_type);
@@ -310,7 +310,7 @@ namespace roundhouse.runners
                 string destination_file = file_system.combine_paths(known_folders.change_drop.folder_full_path, "itemsRan",
                                                                     sql_file_ran.Replace(migration_folder.folder_path + "\\", string.Empty));
                 file_system.verify_or_create_directory(file_system.get_directory_name_from(destination_file));
-                Log.bound_to(this).log_a_debug_event_containing("Copying file {0} to {1}.", file_system.get_file_name_from(sql_file_ran), destination_file);
+                Log.bound_to(this).log_a_debug_event_containing("Copying file {0} to {1}.", file_system.get_file_name_from(sql_file_ran, migration_folder), destination_file);
                 file_system.file_copy_unsafe(sql_file_ran, destination_file, true);
             }
         }


### PR DESCRIPTION
Change the Migration Runner to identify files by their relative path
to the migration folder, instead of their filename. This allows files
with the same name to exist in different subdirectories of a migration
folder. Before this change RoundhousE only considered the filename when
checking if it had run the file previously.

e.g. Having a directory layout like this:
up
 |- feature1
 |   |- 001.sql
 |
 |- feature2
     |- 001.sql

Will now run successfully by roundhouse, previously it would identify
'feature2\001.sql' as being a modified copy of 'feature1\001.sql'.

Log messages and the script_name column in the ScriptsRun and
ScriptsRunErrors now store the script_name like 'feature1\001.sql'
instead of '001.sql'.

WARNING:
If you run this on a database already managed by RoundhousE that has
scripts inside subfolders of the migration folders it will re-run those
scripts, because only the filename portion was stored by versions of
RoundHouse before this commit.
