### PR TITLE
Add option to run aftercreate with/out transaction

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -263,6 +263,20 @@
                 .Add("t|trx|transaction|wt|withtransaction",
                      "WithTransaction - This instructs RH to run inside of a transaction. Defaults to false.",
                      option => configuration.WithTransaction = option != null)
+                // Run After Create Scripts in a transaction
+                .Add("runAfterCreateWithTransaction=",
+                    "runAfterCreateWithTransaction - This instructs RH whether to run the afterCreate scripts inside a transaction. Defaults to withtransaction option",
+                    option => {
+                        // Only set it if the option is explicit here.
+                        if ("true" == option)
+                        {
+                            configuration.RunAfterCreateScriptWithTransaction = true;
+                        }
+                        else if("false" == option)
+                        {
+                            configuration.RunAfterCreateScriptWithTransaction = false;
+                        }
+                    })
                 //recovery mode
                 .Add("simple",
                      "RecoveryModeSimple - This instructs RH to set the database recovery mode to simple recovery. Defaults to false.",

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -132,6 +132,19 @@
 
         public bool DisableOutput { get; set; }
 
+        private bool? _runAfterCreateScriptWithTransaction;
+        public bool RunAfterCreateScriptWithTransaction
+        {
+            get
+            {
+                return _runAfterCreateScriptWithTransaction ?? WithTransaction;
+            }
+            set
+            {
+                _runAfterCreateScriptWithTransaction = value;
+            }
+        }
+
         #endregion
 
         public void run_the_task()

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -56,5 +56,17 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
+        private bool? _runAfterCreateScriptWithTransaction;
+        public bool RunAfterCreateScriptWithTransaction
+        {
+            get
+            {
+                return _runAfterCreateScriptWithTransaction ?? WithTransaction;
+            }
+            set
+            {
+                _runAfterCreateScriptWithTransaction = value;
+            }
+        }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -56,5 +56,6 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
+        bool RunAfterCreateScriptWithTransaction { get; set; }
     }
 }

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -137,7 +137,20 @@ namespace roundhouse.runners
 
                     if (database_was_created)
                     {
+                        // Allow different transaction settings for the RunAfterCreateScripts
+                        if (run_in_a_transaction != configuration.RunAfterCreateScriptWithTransaction)
+                        {
+                            database_migrator.close_connection();
+                            database_migrator.open_connection(configuration.RunAfterCreateScriptWithTransaction);
+                        }
+
                         log_and_traverse(known_folders.run_after_create_database, version_id, new_version, ConnectionType.Default);
+
+                        if (run_in_a_transaction != configuration.RunAfterCreateScriptWithTransaction)
+                        {
+                            database_migrator.close_connection();
+                            database_migrator.open_connection(run_in_a_transaction);
+                        }
                     }
 
                     log_and_traverse(known_folders.up, version_id, new_version, ConnectionType.Default);


### PR DESCRIPTION
Add the runAfterCreateWithTransaction option which allows you to
independently control whether the after create scripts are run inside a
transaction or not. By default it is the same value as the
withTransaction option.

The rationale is that not all aftercreate scripts are transaction
compatiable and that since they are only run just after database
creation it should be fine to run outside a transaction.
