### PR TITLE
Change the StatementSplitter to handle combinations of string literals, comments and batch seperators

### DIFF
--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -14,7 +14,15 @@ namespace roundhouse.databases.sqlserver
 
         public override string sql_statement_separator_regex_pattern
         {
-            get { return @"(?<KEEP1>^(?:[\s\t])*(?:-{2}).*$)|(?<KEEP1>/{1}\*{1}[\S\s]*?\*{1}/{1})|(?<KEEP1>'{1}(?:[^']|\n[^'])*?'{1})|(?<KEEP1>\s)(?<BATCHSPLITTER>GO)(?<KEEP2>\s)|(?<KEEP1>\s)(?<BATCHSPLITTER>GO)(?<KEEP2>$)"; }
+            get { throw new NotSupportedException("Use sql_splitter instead"); }
+        }
+
+        public override sqlsplitters.StatementSplitter sql_splitter
+        {
+            get
+            {
+                return new SqlServerStatementSplitter();
+            }
         }
 
         public override void initialize_connections(ConfigurationPropertyHolder configuration_property_holder)

--- a/product/roundhouse.databases.sqlserver/SqlServerStatementSplitter.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerStatementSplitter.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using roundhouse.sqlsplitters;
+
+namespace roundhouse.databases.sqlserver
+{
+    /// <summary>
+    /// Class which splits SQL Server statements based on batch identifiers.
+    /// </summary>
+    public class SqlServerStatementSplitter : StatementSplitter
+    {
+
+        /// <summary>
+        /// Splits the sql using the BreakIntoBatches method, removing empty and whitespace only batches.
+        /// </summary>
+        /// <param name="sql_batches"></param>
+        /// <returns></returns>
+        public IEnumerable<string> split(string sql_batches)
+        {
+            // regular expression to match something other than
+            // whitespace.
+            var nonWhitespace = new Regex(@"\S");
+            return BreakIntoBatches(sql_batches).Where(batch => batch.Any() && nonWhitespace.IsMatch(batch));
+        }
+
+        private class Token
+        {
+            public Token(TokenType type, int index, int length)
+            {
+                Type = type;
+                Index = index;
+                Length = length;
+            }
+
+            public TokenType Type { get; private set; }
+            public int Index { get; private set; }
+            public int Length { get; private set; }
+        }
+
+        private enum TokenType
+        {
+            BATCH_SEPERATOR,
+            STRING_DELIMITER,
+            MULTI_LINE_COMMENT_START,
+            MULTI_LINE_COMMENT_END,
+            SINGLE_LINE_COMMENT_START,
+            NEW_LINE
+        }
+
+        /// <summary>
+        /// Break the sql batch into a sequence of tokens
+        /// </summary>
+        /// <param name="sql_batch">The sql that we are tokenizing (including batch seperators)</param>
+        /// <returns>The sequence of tokens that exists in the sql batch.</returns>
+        private IEnumerator<Token> Tokenizer(string sql_batch)
+        {
+            // Single unified token pattern so we only do one pass over the whole thing.
+            var tokenPattern = new Regex(@"(\b(?<BATCH_SEPERATOR>GO)\b)|
+                                    (?<STRING_DELIMITER>')|
+                                    (?<MULTI_LINE_COMMENT_START>/\*)|
+                                    (?<MULTI_LINE_COMMENT_END>\*/)|
+                                    (?<SINGLE_LINE_COMMENT_START>--)|
+                                    (?<NEW_LINE>$)",
+                                  RegexOptions.Multiline | 
+                                  RegexOptions.IgnorePatternWhitespace |
+                                  RegexOptions.ExplicitCapture);
+            var match = tokenPattern.Match(sql_batch);
+            while(match.Success)
+            {
+                // unfortunately need to query for each individual 
+                // capturing group rather than working backwards to find
+                // the token type. (Also GetGroupNames() returns "0" as well as the names, so need
+                // to use the enums and ToString().
+                foreach(var tokenType in (TokenType[])Enum.GetValues(typeof(TokenType)))
+                {
+                    var group = match.Groups[tokenType.ToString()];
+                    if(group.Success)
+                    {
+                        yield return new Token(
+                            type: tokenType,
+                            index: group.Index,
+                            length: group.Length
+                        );
+                        break;
+                    }
+                }
+
+                match = match.NextMatch();
+            }
+        }
+
+        /// <summary>
+        /// Break the sql into a sequence of batches.
+        /// </summary>
+        /// <param name="sql_batch">The complete sql including batch seperators</param>
+        /// <returns>The sql batches</returns>
+        private IEnumerable<string> BreakIntoBatches(string sql_batch)
+        {
+            // We use a tokenizer to convert the batch into a sequence
+            // of tokens so we know when to split it, taking into account
+            // string literals and comments.
+            using (var tokens = Tokenizer(sql_batch))
+            {
+                int currentCutIndex = 0;
+
+                Token token = null;
+                // Helper function to set the current token
+                // and to let us know if there are anymore tokens.
+                Func<bool> getNextToken = () =>
+                                              {
+                                                  if (tokens.MoveNext())
+                                                  {
+                                                      token = tokens.Current;
+                                                      return true;
+                                                  }
+                                                  return false;
+                                              };
+
+                while (getNextToken())
+                {
+                    switch (token.Type)
+                    {
+                        case TokenType.BATCH_SEPERATOR:
+                            yield return sql_batch.Substring(currentCutIndex, token.Index - currentCutIndex);
+                            currentCutIndex = token.Index + token.Length;
+                            break;
+                        case TokenType.STRING_DELIMITER:
+                            // skip over everything until we get out of the string.
+                            while(getNextToken())
+                            {
+                                if(token.Type == TokenType.STRING_DELIMITER)
+                                {
+                                    break;
+                                }
+                            }
+                            break;
+                        case TokenType.MULTI_LINE_COMMENT_START:
+                            // run until we get out of the comment.
+                            int commentDepth = 1;
+                            while(commentDepth > 0 && getNextToken())
+                            {
+                                if(token.Type == TokenType.MULTI_LINE_COMMENT_START)
+                                {
+                                    commentDepth++;
+                                }
+                                if(token.Type == TokenType.MULTI_LINE_COMMENT_END)
+                                {
+                                    commentDepth--;
+                                }
+                            }
+                            break;
+                        case TokenType.SINGLE_LINE_COMMENT_START:
+                            // consume until we get out of the comment
+                            while(getNextToken())
+                            {
+                                if(token.Type == TokenType.NEW_LINE)
+                                {
+                                    // done here.
+                                    break;
+                                }
+                            }
+                            break;
+                        case TokenType.NEW_LINE:
+                            // all good, just skip these. 
+                            break;
+                        // Shouldn't get here:
+                        case TokenType.MULTI_LINE_COMMENT_END:
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+
+                // Remember to return the remainder. (There isn't an end of document token).
+                yield return sql_batch.Substring(currentCutIndex);
+            }
+        }
+    }
+}

--- a/product/roundhouse.databases.sqlserver/SqlServerStatementSplitter.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerStatementSplitter.cs
@@ -66,7 +66,8 @@ namespace roundhouse.databases.sqlserver
                                     (?<NEW_LINE>$)",
                                   RegexOptions.Multiline | 
                                   RegexOptions.IgnorePatternWhitespace |
-                                  RegexOptions.ExplicitCapture);
+                                  RegexOptions.ExplicitCapture |
+                                  RegexOptions.IgnoreCase);
             var match = tokenPattern.Match(sql_batch);
             while(match.Success)
             {

--- a/product/roundhouse.databases.sqlserver/roundhouse.databases.sqlserver.csproj
+++ b/product/roundhouse.databases.sqlserver/roundhouse.databases.sqlserver.csproj
@@ -91,6 +91,7 @@
     <Compile Include="orm\VersionMapping.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerDatabase.cs" />
+    <Compile Include="SqlServerStatementSplitter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\roundhouse\roundhouse.csproj">

--- a/product/roundhouse.tests/sqlsplitters/SplitterContext.cs
+++ b/product/roundhouse.tests/sqlsplitters/SplitterContext.cs
@@ -98,25 +98,25 @@ INSERT [dbo].[Foo] ([Bar]) VALUES (N'Go speed racer, go speed racer, go speed ra
 
 GO";
 
-			public static string tsql_statement_scrubbed = @"
+			public static string[] tsql_statement_scrubbed = new [] { @"
 BOB1
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 /* COMMENT */
 BOB2
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 -- GO
 
-BOB3 " + StatementSplitter.batch_terminator_replacement_string + @"
+BOB3  " , @" 
 
 --`~!@#$%^&*()-_+=,.;:'""[]\/?<> GO
 
 BOB5
-   " + StatementSplitter.batch_terminator_replacement_string + @"
+    " , @" 
 
 BOB6
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 /* GO */
 
@@ -131,12 +131,12 @@ GO
 BOB8
 
 --
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 BOB9
 
 -- `~!@#$%^&*()-_+=,.;:'""[]\/?<>
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 BOB10GO
 
@@ -164,7 +164,7 @@ ALTER TABLE Inv.something ADD
 	slsald varchar(15) NULL,
 	uhasdf varchar(15) NULL,
     daf_asdfasdf DECIMAL(20,6) NULL;
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 EXEC @ReturnCode = msdb.dbo.sp_add_jobstep @job_id=@jobId, @step_name=N'Daily job', 
 		@step_id=1, 
@@ -181,13 +181,13 @@ dml statements
 GO  
 dml statements '
 
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 
 INSERT [dbo].[Foo] ([Bar]) VALUES (N'hello--world.
 Thanks!')
 INSERT [dbo].[Foo] ([Bar]) VALUES (N'Go speed racer, go speed racer, go speed racer go!!!!! ')
 
-"+ StatementSplitter.batch_terminator_replacement_string + @"";
+ "};
 
         	public static string plsql_statement =
 				@"
@@ -203,19 +203,19 @@ INSERT into Table (columnname) values ("";"");
 UPDATE Table set columnname="";"";
 END;
 ";
-			public static string plsql_statement_scrubbed = @"
+			public static string[] plsql_statement_scrubbed = new string[] { @"
 SQL1;
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 SQL2;
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 tmpSql := 'DROP SEQUENCE mutatieStockID';
 EXECUTE IMMEDIATE tmpSql; 
-" + StatementSplitter.batch_terminator_replacement_string + @"
+ " , @" 
 BEGIN
 INSERT into Table (columnname) values ("";"");
 UPDATE Table set columnname="";"";
 END;
-";
+" };
         }
     }
 }

--- a/product/roundhouse.tests/sqlsplitters/SplitterContext.cs
+++ b/product/roundhouse.tests/sqlsplitters/SplitterContext.cs
@@ -100,23 +100,23 @@ GO";
 
 			public static string[] tsql_statement_scrubbed = new [] { @"
 BOB1
- " , @" 
+" , @"
 
 /* COMMENT */
 BOB2
- " , @" 
+" , @"
 
 -- GO
 
-BOB3  " , @" 
+BOB3 " , @"
 
 --`~!@#$%^&*()-_+=,.;:'""[]\/?<> GO
 
 BOB5
-    " , @" 
+   " , @"
 
 BOB6
- " , @" 
+" , @"
 
 /* GO */
 
@@ -131,12 +131,12 @@ GO
 BOB8
 
 --
- " , @" 
+" , @"
 
 BOB9
 
 -- `~!@#$%^&*()-_+=,.;:'""[]\/?<>
- " , @" 
+" , @"
 
 BOB10GO
 
@@ -164,7 +164,7 @@ ALTER TABLE Inv.something ADD
 	slsald varchar(15) NULL,
 	uhasdf varchar(15) NULL,
     daf_asdfasdf DECIMAL(20,6) NULL;
- " , @" 
+" , @"
 
 EXEC @ReturnCode = msdb.dbo.sp_add_jobstep @job_id=@jobId, @step_name=N'Daily job', 
 		@step_id=1, 
@@ -181,13 +181,13 @@ dml statements
 GO  
 dml statements '
 
- " , @" 
+" , @"
 
 INSERT [dbo].[Foo] ([Bar]) VALUES (N'hello--world.
 Thanks!')
 INSERT [dbo].[Foo] ([Bar]) VALUES (N'Go speed racer, go speed racer, go speed racer go!!!!! ')
 
- "};
+"};
 
         	public static string plsql_statement =
 				@"

--- a/product/roundhouse.tests/sqlsplitters/StatementSplitterSpecs.cs
+++ b/product/roundhouse.tests/sqlsplitters/StatementSplitterSpecs.cs
@@ -46,6 +46,17 @@ namespace roundhouse.tests.sqlsplitters
                                     };
 
             [Observation]
+            public void should_replace_on_lowercase_go_statement()
+            {
+                string sql_to_match = "\r\nwhere DataName = 'AttributeKeyMap'\r\ngo ";
+                Console.WriteLine(sql_to_match);
+                var expected = new[] { "\r\nwhere DataName = 'AttributeKeyMap'\r\n" };
+
+                var sql_statement_scrubbed = splitter.split(sql_to_match).ToArray();
+                CollectionAssert.AreEqual(expected, sql_statement_scrubbed);
+            }
+
+            [Observation]
             public void should_replace_on_full_statement_without_issue()
             {
                 string sql_to_match = SplitterContext.FullSplitter.tsql_statement;

--- a/product/roundhouse/databases/Database.cs
+++ b/product/roundhouse/databases/Database.cs
@@ -60,6 +60,8 @@
 // t##K#       i,                                j       
 //      ;i                                           
 
+using roundhouse.sqlsplitters;
+
 namespace roundhouse.databases
 {
     using System;
@@ -109,5 +111,7 @@ namespace roundhouse.databases
         bool has_run_script_already(string script_name);
         string get_current_script_hash(string script_name);
         //object run_sql_scalar(string sql_to_run);
+
+        StatementSplitter sql_splitter { get; }
     }
 }

--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -39,6 +39,14 @@ namespace roundhouse.databases
             get { return @"(?<KEEP1>^(?:[\s\t])*(?:-{2}).*$)|(?<KEEP1>/{1}\*{1}[\S\s]*?\*{1}/{1})|(?<KEEP1>'{1}(?:[^']|\n[^'])*?'{1})|(?<KEEP1>\s)(?<BATCHSPLITTER>\;)(?<KEEP2>\s)|(?<KEEP1>\s)(?<BATCHSPLITTER>\;)(?<KEEP2>$)"; }
         }
 
+        public virtual StatementSplitter sql_splitter
+        {
+            get
+            {
+                return new DefaultStatementSplitter(sql_statement_separator_regex_pattern);
+            }
+        }
+
         public int command_timeout { get; set; }
         public int admin_command_timeout { get; set; }
         public int restore_timeout { get; set; }
@@ -101,7 +109,7 @@ namespace roundhouse.databases
 
                 if (split_batch_statements)
                 {
-                    foreach (var sql_statement in StatementSplitter.split_sql_on_regex_and_remove_empty_statements(create_script, sql_statement_separator_regex_pattern))
+                    foreach (var sql_statement in sql_splitter.split(create_script))
                     {
                         //should only receive a return value once
                         var return_value = run_sql_scalar_boolean(sql_statement, ConnectionType.Admin);

--- a/product/roundhouse/databases/MockDatabase.cs
+++ b/product/roundhouse/databases/MockDatabase.cs
@@ -1,3 +1,5 @@
+using roundhouse.sqlsplitters;
+
 namespace roundhouse.databases
 {
     using System;
@@ -268,6 +270,14 @@ namespace roundhouse.databases
             {
                 database.Dispose();
                 disposing = true;
+            }
+        }
+
+        public StatementSplitter sql_splitter 
+        {
+            get
+            {
+                return database.sql_splitter;
             }
         }
     }

--- a/product/roundhouse/databases/SqlServerLiteSpeedDatabase.cs
+++ b/product/roundhouse/databases/SqlServerLiteSpeedDatabase.cs
@@ -1,3 +1,5 @@
+using roundhouse.sqlsplitters;
+
 namespace roundhouse.databases
 {
     using System;
@@ -253,6 +255,14 @@ namespace roundhouse.databases
             {
                 database.Dispose();
                 disposing = true;
+            }
+        }
+
+        public StatementSplitter sql_splitter 
+        {
+            get
+            {
+                return database.sql_splitter;
             }
         }
     }

--- a/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
+++ b/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
@@ -212,7 +212,7 @@ namespace roundhouse.migrators
 
             if (database.split_batch_statements)
             {
-                foreach (var sql_statement in StatementSplitter.split_sql_on_regex_and_remove_empty_statements(sql_to_run, database.sql_statement_separator_regex_pattern))
+                foreach (var sql_statement in  database.sql_splitter.split(sql_to_run))
                 {
                     sql_statements.Add(sql_statement);
                 }

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -137,7 +137,7 @@
     <Compile Include="RoundhouseMode.cs" />
     <Compile Include="runners\RoundhouseNHibernateCompareRunner.cs" />
     <Compile Include="runners\RoundhouseRedGateCompareRunner.cs" />
-    <Compile Include="sqlsplitters\StatementSplitter.cs" />
+    <Compile Include="sqlsplitters\DefaultStatementSplitter.cs" />
     <Compile Include="consoles\DefaultConfiguration.cs" />
     <Compile Include="cryptography\CryptographicService.cs" />
     <Compile Include="cryptography\MD5CryptographicService.cs" />
@@ -191,6 +191,7 @@
     <Compile Include="migrators\DatabaseMigrator.cs" />
     <Compile Include="migrators\DefaultDatabaseMigrator.cs" />
     <Compile Include="databases\SqlServerLiteSpeedDatabase.cs" />
+    <Compile Include="sqlsplitters\StatementSplitter.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="infrastructure.app\logging\log4net.config.xml" />

--- a/product/roundhouse/sqlsplitters/DefaultStatementSplitter.cs
+++ b/product/roundhouse/sqlsplitters/DefaultStatementSplitter.cs
@@ -1,0 +1,57 @@
+namespace roundhouse.sqlsplitters
+{
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+    using infrastructure.extensions;
+
+    public class DefaultStatementSplitter : StatementSplitter
+    {
+        public DefaultStatementSplitter(string sql_statement_separator_regex_pattern)
+        {
+            this.sql_statement_separator_regex_pattern = sql_statement_separator_regex_pattern;
+        }
+
+        private string sql_statement_separator_regex_pattern;
+
+        private static string batch_terminator_replacement_string = @" |{[_REMOVE_]}| ";
+        private static string regex_split_string = @"\|\{\[_REMOVE_\]\}\|";
+
+        public IEnumerable<string> split(string sql_to_run)
+        {
+            IList<string> return_sql_list = new List<string>();
+
+            Regex regex_replace = new Regex(sql_statement_separator_regex_pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+            string sql_statement_scrubbed = regex_replace.Replace(sql_to_run, match => evaluate_and_replace_batch_split_items(match, regex_replace));
+
+            foreach (string sql_statement in Regex.Split(sql_statement_scrubbed, regex_split_string, RegexOptions.IgnoreCase | RegexOptions.Multiline))
+            {
+                if (script_has_text_to_run(sql_statement, sql_statement_separator_regex_pattern))
+                {
+                    return_sql_list.Add(sql_statement);
+                }
+            }
+
+            return return_sql_list;
+        }
+
+        private static string evaluate_and_replace_batch_split_items(Match matched_item, Regex regex)
+        {
+            if (matched_item.Groups["BATCHSPLITTER"].Success)
+            {
+                return matched_item.Groups["KEEP1"].Value + batch_terminator_replacement_string + matched_item.Groups["KEEP2"].Value;
+            }
+            else
+            {
+                return matched_item.Groups["KEEP1"].Value + matched_item.Groups["KEEP2"].Value;
+            }
+        }
+
+        private static bool script_has_text_to_run(string sql_statement, string sql_statement_separator_regex_pattern)
+        {
+            sql_statement = Regex.Replace(sql_statement, regex_split_string, string.Empty, RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+            return !string.IsNullOrEmpty(sql_statement.to_lower().Replace(System.Environment.NewLine, string.Empty).Replace(" ", string.Empty));
+        }
+    }
+}

--- a/product/roundhouse/sqlsplitters/StatementSplitter.cs
+++ b/product/roundhouse/sqlsplitters/StatementSplitter.cs
@@ -1,50 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
 namespace roundhouse.sqlsplitters
 {
-    using System.Collections.Generic;
-    using System.Text.RegularExpressions;
-    using infrastructure.extensions;
-
-    public class StatementSplitter
+    /// <summary>
+    /// Provides an interface to Split Sql strings.
+    /// </summary>
+    public interface StatementSplitter
     {
-        public static string batch_terminator_replacement_string = @" |{[_REMOVE_]}| ";
-        public static string regex_split_string = @"\|\{\[_REMOVE_\]\}\|";
-
-        public static IEnumerable<string> split_sql_on_regex_and_remove_empty_statements(string sql_to_run, string sql_statement_separator_regex_pattern)
-        {
-            IList<string> return_sql_list = new List<string>();
-
-            Regex regex_replace = new Regex(sql_statement_separator_regex_pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
-
-            string sql_statement_scrubbed = regex_replace.Replace(sql_to_run, match => evaluate_and_replace_batch_split_items(match, regex_replace));
-
-            foreach (string sql_statement in Regex.Split(sql_statement_scrubbed, regex_split_string, RegexOptions.IgnoreCase | RegexOptions.Multiline))
-            {
-                if (script_has_text_to_run(sql_statement, sql_statement_separator_regex_pattern))
-                {
-                    return_sql_list.Add(sql_statement);
-                }
-            }
-
-            return return_sql_list;
-        }
-
-        public static string evaluate_and_replace_batch_split_items(Match matched_item, Regex regex)
-        {
-            if (matched_item.Groups["BATCHSPLITTER"].Success)
-            {
-                return matched_item.Groups["KEEP1"].Value + batch_terminator_replacement_string + matched_item.Groups["KEEP2"].Value;
-            }
-            else
-            {
-                return matched_item.Groups["KEEP1"].Value + matched_item.Groups["KEEP2"].Value;
-            }
-        }
-
-        private static bool script_has_text_to_run(string sql_statement, string sql_statement_separator_regex_pattern)
-        {
-            sql_statement = Regex.Replace(sql_statement, regex_split_string, string.Empty, RegexOptions.IgnoreCase | RegexOptions.Multiline);
-
-            return !string.IsNullOrEmpty(sql_statement.to_lower().Replace(System.Environment.NewLine, string.Empty).Replace(" ", string.Empty));
-        }
+        /// <summary>
+        /// Splits the provided sql into batches.
+        /// </summary>
+        /// <param name="sql_batch">The sql to split</param>
+        /// <returns>Enumeration of Sql Batches</returns>
+        IEnumerable<string> split(string sql);
     }
 }


### PR DESCRIPTION
Change RoundHouse to handle mixing of the following for sql server:
- Single line comments `--`
- Multi line comments `/* newline */`
- Nested comments `/* /* nested */ */`
- String literals `'hello there'`
- Batch seperators `GO`

Changes to roundhouse include:
- Added Unit Tests for the regression introduced by [a297dd4](https://github.com/chucknorris/roundhouse/commit/a297dd4) and simliar examples.
- Refactored the Statement Splitter logic into an interface.
- Changed Unit Tests to check on the Split sql, not the replacement of terminators with a "split" string.
- Implemented a tokenizer based splitter for SQL Server.

The SqlServerStatement splitter uses a regular expression to just tokenize the sql. An outer loop then only breaks the sql on "go" statements that are outside of comments or string literals. This has the added advantage of not introducing whitespace into sql batches.

Only SQL Server database targets are affected by these changes
