### PR TITLE
Fix Restore so that it uses the restore timeout

### DIFF
--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -167,9 +167,9 @@ namespace roundhouse.databases
             try
             {
                 int current_connection_timeout = command_timeout;
-                command_timeout = restore_timeout;
+                admin_command_timeout = restore_timeout;
                 run_sql(restore_database_script(restore_from_path, custom_restore_options), ConnectionType.Admin);
-                command_timeout = current_connection_timeout;
+                admin_command_timeout = current_connection_timeout;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Change the Restore method to override the admin connection timeout with
the restore timeout instead of the normal connection timeout. This
causes RH to respect the restore timeout parameter, as before it used
the admin connection timeout instead of the restore timeout.
