### PR TITLE
Add explicit file encoding option

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -305,6 +305,15 @@ namespace roundhouse.console
                 .Add("searchallinsteadoftraverse=|searchallsubdirectoriesinsteadoftraverse=",
                      "SearchAllSubdirectoriesInsteadOfTraverse - Each Migration folder's subdirectories are traversed by default. This option pulls back scripts from the main directory and all subdirectories at once. Defaults to 'false'",
                      option => configuration.SearchAllSubdirectoriesInsteadOfTraverse = option != null)
+                .Add("fileencoding=",
+                     "File Encoding - Explicitly specify the file encoding of all files",
+                     option =>
+                         {
+                             if(option != null)
+                             {
+                                 configuration.FileEncoding = System.Text.Encoding.GetEncoding(option);
+                             }
+                         })
                 ;
 
             try

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -132,6 +132,8 @@
 
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
 
+        public System.Text.Encoding FileEncoding { get; set; }
+
         public bool DisableOutput { get; set; }
 
         #endregion

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -57,5 +57,6 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
+        public System.Text.Encoding FileEncoding { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -57,5 +57,6 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
+        System.Text.Encoding FileEncoding { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
@@ -63,8 +63,12 @@ namespace roundhouse.infrastructure.filesystem
         /// <param name="file_path">Path to the file name</param>
         /// <returns>A best guess at the encoding of the file</returns>
         /// <remarks>http://www.west-wind.com/WebLog/posts/197245.aspx</remarks>
-        public static Encoding get_file_encoding(string file_path)
+        public Encoding get_file_encoding(string file_path)
         {
+            if(configuration.FileEncoding != null)
+            {
+                return configuration.FileEncoding;
+            }
             // *** Use Default of Encoding.Default (Ansi CodePage)
             Encoding enc = Encoding.Default;
 


### PR DESCRIPTION
Add option "fileencoding=" which allows the RH to be told explicitly
what file encoding it should use to read files. If no encoding is
specified it falls back to the existing auto-detection logic.

This is useful if your script files are encoded in UTF-8 without the
BOM.
