### PR TITLE
Added option to run scripts before and after the transaction scope

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -195,16 +195,12 @@ namespace roundhouse.console
                          "PermissionsFolderName - The name of the folder where you keep your permissions scripts. Will recurse through subfolders. Defaults to \"{0}\".",
                          ApplicationParameters.default_permissions_folder_name),
                      option => configuration.PermissionsFolderName = option)
-                .Add("btr=|beforetran=|beforetransaction=|beforetransactionfoldername=",
-                     string.Format(
-                         "BeforeTransactionFolderName - The name of the folder where you keep your scripts that needs to run before transaction scope begins. Will recurse through subfolders. Defaults to \"{0}\".",
-                         ApplicationParameters.default_before_transaction_folder_name),
-                     option => configuration.BeforeTransactionFolderName = option)
-                .Add("atr=|aftertran=|aftertransaction=|aftertransactionfoldername=",
-                     string.Format(
-                         "AfterTransactionFolderName - The name of the folder where you keep your scripts that needs to run after transaction scope ends. Will recurse through subfolders. Defaults to \"{0}\".",
-                         ApplicationParameters.default_after_transaction_folder_name),
-                     option => configuration.AfterTransactionFolderName = option)
+                .Add("bmg=|beforemig=|beforemigrationfolder=|beforemigrationfoldername=",
+                         "BeforeMigrationFolderName - The name of the folder where you keep your scripts that needs to run before migration. Script will run outside of transaction. Will recurse through subfolders.",
+                     option => configuration.BeforeMigrationFolderName = option)
+                .Add("amg=|aftermig=|aftermigrationfolder=|aftermigrationfoldername=",
+                         "AfterMigrationFolderName - The name of the folder where you keep your scripts that needs to run after migration. Script will run outside of transaction. Will recurse through subfolders.",
+                     option => configuration.AfterMigrationFolderName = option)
                 // roundhouse items
                 .Add("sc=|schema=|schemaname=",
                      string.Format(

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -81,9 +81,9 @@
 
         public string PermissionsFolderName { get; set; }
 
-        public string BeforeTransactionFolderName { get; set; }
+        public string BeforeMigrationFolderName { get; set; }
 
-        public string AfterTransactionFolderName { get; set; }
+        public string AfterMigrationFolderName { get; set; }
 
         public string SchemaName { get; set; }
 

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -30,8 +30,8 @@ namespace roundhouse.consoles
         public string IndexesFolderName { get; set; }
         public string RunAfterOtherAnyTimeScriptsFolderName { get; set; }
         public string PermissionsFolderName { get; set; }
-        public string BeforeTransactionFolderName { get; set; }
-        public string AfterTransactionFolderName { get; set; }
+        public string BeforeMigrationFolderName { get; set; }
+        public string AfterMigrationFolderName { get; set; }
         public string SchemaName { get; set; }
         public string VersionTableName { get; set; }
         public string ScriptsRunTableName { get; set; }

--- a/product/roundhouse/folders/DefaultKnownFolders.cs
+++ b/product/roundhouse/folders/DefaultKnownFolders.cs
@@ -15,8 +15,8 @@ namespace roundhouse.folders
                                    MigrationsFolder indexes,
                                    MigrationsFolder runAfterOtherAnyTimeScripts,        
                                    MigrationsFolder permissions,
-                                   MigrationsFolder before_transaction,
-                                   MigrationsFolder after_transaction,
+                                   MigrationsFolder before_migration,
+                                   MigrationsFolder after_migration,
                                    Folder change_drop
             )
         {
@@ -33,8 +33,8 @@ namespace roundhouse.folders
             this.run_after_other_any_time_scripts = runAfterOtherAnyTimeScripts;
             this.permissions = permissions;
             this.change_drop = change_drop;
-            this.before_transaction = before_transaction;
-            this.after_transaction = after_transaction;
+            this.before_migration = before_migration;
+            this.after_migration = after_migration;
         }
 
         public MigrationsFolder alter_database { get; private set; }
@@ -49,8 +49,8 @@ namespace roundhouse.folders
         public MigrationsFolder indexes { get; private set; }
         public MigrationsFolder run_after_other_any_time_scripts { get; private set; }
         public MigrationsFolder permissions { get; private set; }
-        public MigrationsFolder before_transaction { get; private set; }
-        public MigrationsFolder after_transaction { get; private set; }
+        public MigrationsFolder before_migration { get; private set; }
+        public MigrationsFolder after_migration { get; private set; }
 
         public Folder change_drop{get; private set;}
        

--- a/product/roundhouse/folders/KnownFolders.cs
+++ b/product/roundhouse/folders/KnownFolders.cs
@@ -14,8 +14,8 @@ namespace roundhouse.folders
         MigrationsFolder indexes { get; }
         MigrationsFolder run_after_other_any_time_scripts { get; }
         MigrationsFolder permissions { get; }
-        MigrationsFolder before_transaction { get; }
-        MigrationsFolder after_transaction { get; }
+        MigrationsFolder before_migration { get; }
+        MigrationsFolder after_migration { get; }
         Folder change_drop { get; }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -30,8 +30,8 @@ namespace roundhouse.infrastructure.app
         string IndexesFolderName { get; set; }
         string RunAfterOtherAnyTimeScriptsFolderName { get; set; }
         string PermissionsFolderName { get; set; }
-        string BeforeTransactionFolderName { get; set; }
-        string AfterTransactionFolderName { get; set; }
+        string BeforeMigrationFolderName { get; set; }
+        string AfterMigrationFolderName { get; set; }
         string SchemaName { get; set; }
         string VersionTableName { get; set; }
         string ScriptsRunTableName { get; set; }

--- a/product/roundhouse/infrastructure.app/builders/KnownFoldersBuilder.cs
+++ b/product/roundhouse/infrastructure.app/builders/KnownFoldersBuilder.cs
@@ -20,8 +20,8 @@ namespace roundhouse.infrastructure.app.builders
             MigrationsFolder indexes_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.IndexesFolderName, false, false, "Index");
             MigrationsFolder runAfterOtherAnyTimeScripts_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.RunAfterOtherAnyTimeScriptsFolderName, false, false, "Run after Other Anytime Scripts");
             MigrationsFolder permissions_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.PermissionsFolderName, false, true, "Permission");
-            MigrationsFolder before_transaction_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.BeforeTransactionFolderName, false, true, "BeforeTransaction");
-            MigrationsFolder after_transaction_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.AfterTransactionFolderName, false, true, "AfterTransaction");
+            MigrationsFolder before_migration_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.BeforeMigrationFolderName, false, true, "BeforeMigration");
+            MigrationsFolder after_migration_folder = new DefaultMigrationsFolder(file_system, configuration_property_holder.SqlFilesDirectory, configuration_property_holder.AfterMigrationFolderName, false, true, "AfterMigration");
 
             Folder change_drop_folder = new DefaultFolder(file_system, combine_items_into_one_path(file_system,
                                                                                                    configuration_property_holder.OutputPath,
@@ -30,7 +30,7 @@ namespace roundhouse.infrastructure.app.builders
                                                                                                    remove_paths_from(configuration_property_holder.ServerName,file_system)),
                                                           get_run_date_time_string());
 
-			return new DefaultKnownFolders(alter_database_folder, run_after_create_database_folder, run_before_up_folder, up_folder, down_folder, run_first_folder, functions_folder, views_folder, sprocs_folder, indexes_folder, runAfterOtherAnyTimeScripts_folder, permissions_folder, before_transaction_folder, after_transaction_folder, change_drop_folder);
+			return new DefaultKnownFolders(alter_database_folder, run_after_create_database_folder, run_before_up_folder, up_folder, down_folder, run_first_folder, functions_folder, views_folder, sprocs_folder, indexes_folder, runAfterOtherAnyTimeScripts_folder, permissions_folder, before_migration_folder, after_migration_folder, change_drop_folder);
         }
 
         private static string combine_items_into_one_path(FileSystemAccess file_system, params string[] paths)

--- a/product/roundhouse/infrastructure/ApplicationParameters.cs
+++ b/product/roundhouse/infrastructure/ApplicationParameters.cs
@@ -22,8 +22,8 @@ namespace roundhouse.infrastructure
         public static readonly string default_indexes_folder_name = "indexes";
         public static readonly string default_runAfterOtherAnyTime_folder_name = "runAfterOtherAnyTimeScripts";
         public static readonly string default_permissions_folder_name = "permissions";
-        public static readonly string default_before_transaction_folder_name = "beforeTransaction";
-        public static readonly string default_after_transaction_folder_name = "afterTransaction";
+        public static readonly string default_before_migration_folder_name = "beforeMigration";
+        public static readonly string default_after_migration_folder_name = "afterMigration";
         public static readonly string default_environment_name = "LOCAL";
         public static readonly string default_roundhouse_schema_name = "RoundhousE";
         public static readonly string default_version_table_name = "Version";

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -130,7 +130,7 @@ namespace roundhouse.runners
                     Log.bound_to(this).log_an_info_event_containing("Migration Scripts");
                     Log.bound_to(this).log_an_info_event_containing("{0}", "=".PadRight(50, '='));
 
-                    run_out_side_of_transaction_folder(known_folders.before_transaction, true, version_id, new_version);
+                    run_out_side_of_transaction_folder(known_folders.before_migration, version_id, new_version);
                     
                     database_migrator.open_admin_connection();
                     log_and_traverse(known_folders.alter_database, version_id, new_version, ConnectionType.Admin);
@@ -163,7 +163,7 @@ namespace roundhouse.runners
                         database_migrator.open_connection(false);
                     }
                     log_and_traverse(known_folders.permissions, version_id, new_version, ConnectionType.Default);
-                    run_out_side_of_transaction_folder(known_folders.after_transaction, false, version_id, new_version);
+                    run_out_side_of_transaction_folder(known_folders.after_migration, version_id, new_version);
 
                     Log.bound_to(this).log_an_info_event_containing(
                         "{0}{0}{1} v{2} has kicked your database ({3})! You are now at version {4}. All changes and backups can be found at \"{5}\".",
@@ -221,12 +221,11 @@ namespace roundhouse.runners
             traverse_files_and_run_sql(folder.folder_full_path, version_id, folder, environment, new_version, connection_type);
         }
 
-        public void run_out_side_of_transaction_folder(MigrationsFolder folder, bool reopen_connection, long version_id, string new_version)
+        public void run_out_side_of_transaction_folder(MigrationsFolder folder, long version_id, string new_version)
         {
-            if (run_in_a_transaction && !string.IsNullOrEmpty(folder.folder_name))
+            if (!string.IsNullOrEmpty(folder.folder_name))
             {
-
-                if (reopen_connection)
+                if (run_in_a_transaction)
                 {
                     database_migrator.close_connection();
                     database_migrator.open_connection(false);
@@ -234,10 +233,10 @@ namespace roundhouse.runners
 
                 log_and_traverse(folder, version_id, new_version, ConnectionType.Default);
 
-                if (reopen_connection)
+                if (run_in_a_transaction)
                 {
                     database_migrator.close_connection();
-                    database_migrator.open_connection(true);
+                    database_migrator.open_connection(run_in_a_transaction);
                 }
             }
         }


### PR DESCRIPTION
This is a duplicate of a closed pull req. I did, old one was done from master, not very smart so closed that one and did the Pull request from a branch instead

Some configure stuff like

``` sql
sp_configure 'Ad Hoc Distributed Queries', 1
reconfigure
```

cant run within the transaction, for these scenarios I added a Before and after transaction folder so you can put these scripts here
