### PR TITLE
[Enhancement] cache information about already ran scripts to speed up script status checks

### DIFF
--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -3,6 +3,7 @@ namespace roundhouse.databases
     using System;
     using System.Collections.Generic;
     using System.Data;
+    using System.Linq;
     using connections;
     using infrastructure.app;
     using infrastructure.app.tokens;
@@ -59,6 +60,7 @@ namespace roundhouse.databases
         protected IConnection<DBCONNECTION> admin_connection;
 
         private bool disposing;
+        private Dictionary<string, ScriptsRun> scripts_cache;
 
         //this method must set the provider
         public abstract void initialize_connections(ConfigurationPropertyHolder configuration_property_holder);
@@ -271,14 +273,14 @@ namespace roundhouse.databases
         {
             string version = "0";
 
-            DetachedCriteria crit = DetachedCriteria.For<Version>()
-                .Add(Restrictions.Eq("repository_path", repository_path ?? string.Empty))
-                .AddOrder(Order.Desc("entry_date"))
-                .SetMaxResults(1);
+            QueryOver<Version> crit = QueryOver.Of<Version>()
+                .Where(x => x.repository_path == (repository_path ?? string.Empty))
+                .OrderBy(x => x.entry_date).Desc
+                .Take(1);
 
             try
             {
-                IList<Version> items = repository.get_with_criteria<Version>(crit);
+                IList<Version> items = repository.get_with_criteria(crit);
                 if (items != null && items.Count > 0)
                 {
                     version = items[0].version;
@@ -321,16 +323,23 @@ namespace roundhouse.databases
 
         public string get_current_script_hash(string script_name)
         {
-            string hash = string.Empty;
+            ScriptsRun script = get_from_script_cache(script_name);
 
-            DetachedCriteria crit = DetachedCriteria.For<ScriptsRun>()
-                .Add(Restrictions.Eq("script_name", script_name))
-                .AddOrder(Order.Desc("id"))
-                .SetMaxResults(1);
+            if (script != null)
+            {
+                return script.text_hash;
+            }
+
+            QueryOver<ScriptsRun> crit = QueryOver.Of<ScriptsRun>()
+                .Where(x => x.script_name == script_name)
+                .OrderBy(x => x.id).Desc
+                .Take(1);
+
+            string hash = string.Empty;
 
             try
             {
-                IList<ScriptsRun> items = repository.get_with_criteria<ScriptsRun>(crit);
+                IList<ScriptsRun> items = repository.get_with_criteria(crit);
                 if (items != null && items.Count > 0)
                 {
                     hash = items[0].text_hash;
@@ -349,16 +358,23 @@ namespace roundhouse.databases
 
         public bool has_run_script_already(string script_name)
         {
+            ScriptsRun script = get_from_script_cache(script_name);
+
+            if (script != null)
+            {
+                return true;
+            }
+
             bool script_has_run = false;
 
-            DetachedCriteria crit = DetachedCriteria.For<ScriptsRun>()
-                .Add(Restrictions.Eq("script_name", script_name))
-                .AddOrder(Order.Desc("id"))
-                .SetMaxResults(1);
+            QueryOver<ScriptsRun> crit = QueryOver.Of<ScriptsRun>()
+                .Where(x => x.script_name == script_name)
+                .OrderBy(x => x.id).Desc
+                .Take(1);
 
             try
             {
-                IList<ScriptsRun> items = repository.get_with_criteria<ScriptsRun>(crit);
+                IList<ScriptsRun> items = repository.get_with_criteria(crit);
                 if (items != null && items.Count > 0)
                 {
                     script_has_run = true;
@@ -402,6 +418,35 @@ namespace roundhouse.databases
                 }
 
                 connection.Dispose();
+            }
+        }
+
+        private ScriptsRun get_from_script_cache(string script_name)
+        {
+            ensure_script_cache();
+
+            ScriptsRun script;
+            if (scripts_cache.TryGetValue(script_name, out script))
+            {
+                return script;
+            }
+
+            return null;
+        }
+
+        private void ensure_script_cache()
+        {
+            if (scripts_cache != null)
+            {
+                return;
+            }
+
+            scripts_cache = new Dictionary<string, ScriptsRun>();
+
+            // latest id overrides possible old one, just like in queries searching for scripts
+            foreach (var script in repository.get_all<ScriptsRun>().OrderBy(x => x.id))
+            {
+                scripts_cache[script.script_name] = script;
             }
         }
     }

--- a/product/roundhouse/infrastructure/persistence/IRepository.cs
+++ b/product/roundhouse/infrastructure/persistence/IRepository.cs
@@ -11,12 +11,12 @@ namespace roundhouse.infrastructure.persistence
         void rollback();
         void finish();
 
-        IList<T> get_all<T>();
-        IList<T> get_with_criteria<T>(DetachedCriteria detachedCriteria);
-        IList<T> get_transformation_with_criteria<T>(DetachedCriteria detachedCriteria);
-        void save_or_update<T>(IList<T> list);
-        void save_or_update<T>(T item);
-        void delete<T>(IList<T> list);
+        IList<T> get_all<T>() where T : class;
+        IList<T> get_with_criteria<T>(QueryOver<T> detachedCriteria) where T : class;
+        IList<T> get_transformation_with_criteria<T>(QueryOver<T> detachedCriteria) where T : class;
+        void save_or_update<T>(IList<T> list) where T : class;
+        void save_or_update<T>(T item) where T : class;
+        void delete<T>(IList<T> list) where T : class;
 
         ITransaction transaction { get;}
         ISessionFactory session_factory { get; }

--- a/product/roundhouse/infrastructure/persistence/Repository.cs
+++ b/product/roundhouse/infrastructure/persistence/Repository.cs
@@ -71,15 +71,14 @@ namespace roundhouse.infrastructure.persistence
             session = null;
         }
 
-        public IList<T> get_all<T>()
+        public IList<T> get_all<T>() where T : class
         {
             IList<T> list;
-            Type persistentClass = typeof(T);
 
             bool not_running_outside_session = session == null;
             if (not_running_outside_session) start(false);
 
-            ICriteria criteria = session.CreateCriteria(persistentClass);
+            IQueryOver<T, T> criteria = session.QueryOver<T>();
             list = criteria.List<T>();
 
             if (not_running_outside_session) finish();
@@ -89,7 +88,7 @@ namespace roundhouse.infrastructure.persistence
             return list;
         }
 
-        public IList<T> get_with_criteria<T>(DetachedCriteria detachedCriteria)
+        public IList<T> get_with_criteria<T>(QueryOver<T> detachedCriteria) where T : class
         {
             if (detachedCriteria == null)
             {
@@ -102,7 +101,7 @@ namespace roundhouse.infrastructure.persistence
             bool not_running_outside_session = session == null;
             if (not_running_outside_session) start(false);
 
-            ICriteria criteria = detachedCriteria.GetExecutableCriteria(session);
+            IQueryOver<T, T> criteria = detachedCriteria.GetExecutableQueryOver(session);
             list = criteria.List<T>();
 
             if (not_running_outside_session) finish();
@@ -112,7 +111,7 @@ namespace roundhouse.infrastructure.persistence
             return list;
         }
 
-        public IList<T> get_transformation_with_criteria<T>(DetachedCriteria detachedCriteria)
+        public IList<T> get_transformation_with_criteria<T>(QueryOver<T> detachedCriteria) where T : class
         {
             if (detachedCriteria == null)
             {
@@ -125,9 +124,9 @@ namespace roundhouse.infrastructure.persistence
             bool running_long_session = session == null;
             if (!running_long_session) start(false);
 
-            ICriteria criteria = detachedCriteria.GetExecutableCriteria(session);
+            IQueryOver<T, T> criteria = detachedCriteria.GetExecutableQueryOver(session);
             list = criteria
-                .SetResultTransformer(new AliasToBeanResultTransformer(typeof(T)))
+                .TransformUsing(Transformers.AliasToBean<T>())
                 .List<T>();
 
             if (!running_long_session) finish();
@@ -137,7 +136,7 @@ namespace roundhouse.infrastructure.persistence
             return list;
         }
 
-        public void save_or_update<T>(IList<T> list)
+        public void save_or_update<T>(IList<T> list) where T : class
         {
             if (list == null || list.Count == 0)
             {
@@ -159,7 +158,7 @@ namespace roundhouse.infrastructure.persistence
             Log.bound_to(this).log_a_debug_event_containing("Saved {0} records of type {1} successfully.", list.Count, typeof(T).Name);
         }
 
-        public void save_or_update<T>(T item)
+        public void save_or_update<T>(T item) where T : class
         {
             if (item == null)
             {
@@ -178,7 +177,7 @@ namespace roundhouse.infrastructure.persistence
             Log.bound_to(this).log_a_debug_event_containing("Saved item of type {0} successfully.", typeof(T).Name);
         }
 
-        public void delete<T>(IList<T> list)
+        public void delete<T>(IList<T> list) where T : class
         {
             if (list == null || list.Count == 0)
             {


### PR DESCRIPTION
When running RoundhousE against Azure SQL it's painstakingly slow because of the round trips that RH makes just to check whether specific script has been ran and what's its hash. When you have over hundred scripts this latency really adds up. I've added a simple cache for looking up existing entries in database. 

I've also updated the NHibernate queries to use QueryOver which gives more compile-time safety