### PR TITLE
Fix null ref error for MySql server_connection

### DIFF
--- a/product/roundhouse.databases.mysql/MySqlDatabase.cs
+++ b/product/roundhouse.databases.mysql/MySqlDatabase.cs
@@ -111,11 +111,10 @@ namespace roundhouse.databases.mysql
             if (string.IsNullOrEmpty(sql_to_run)) return;
 
             //TODO Investigate how pass CommandTimeout into commands which will be during MySqlScript execution.
-            var connection = server_connection.underlying_type().downcast_to<MySqlConnection>();
-            if (connection_type == ConnectionType.Admin)
-            {
-                connection = admin_connection.underlying_type().downcast_to<MySqlConnection>();
-            }
+            var connection = connection_type == ConnectionType.Admin
+                ? admin_connection.underlying_type().downcast_to<MySqlConnection>()
+                : server_connection.underlying_type().downcast_to<MySqlConnection>();
+            
             var script = new MySqlScript(connection, sql_to_run);
             script.Execute();
         }


### PR DESCRIPTION
fix null ref error due to server_connection being null when needing to use admin_connection for MySql

This is to fix issue #136
