### PR TITLE
Pass version via command line argument

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -127,6 +127,9 @@ namespace roundhouse.console
                      string.Format(
                          "RepositoryPath - The repository. A string that can be anything. Used to track versioning along with the version. Defaults to null."),
                      option => configuration.RepositoryPath = option)
+                .Add("v=|version=",
+                     "Version - Specify the version directly instead of looking in a file. If present, ignores file version options.",
+                     option => configuration.Version = option)
                 .Add("vf=|versionfile=",
                      string.Format("VersionFile - Either a .XML file, a .DLL or a .TXT file that a version can be resolved from. Defaults to \"{0}\".",
                                    ApplicationParameters.default_version_file),
@@ -322,7 +325,7 @@ namespace roundhouse.console
                         "/s[ervername] VALUE " +
                         "/c[onnection]s[tring]a[dministration] VALUE " +
                         "/c[ommand]t[imeout] VALUE /c[ommand]t[imeout]a[dmin] VALUE " +
-                        "/r[epositorypath] VALUE /v[ersion]f[ile] VALUE /v[ersion]x[path] VALUE " +
+                        "/r[epositorypath] VALUE /v[ersion] VALUE /v[ersion]f[ile] VALUE /v[ersion]x[path] VALUE " +
                         "/a[lter]d[atabasefoldername] /r[un]a[fter]c[reate]d[atabasefoldername] VALUE VALUE " +
                         "/r[un]b[eforeupfoldername] VALUE /u[pfoldername] VALUE /do[wnfoldername] VALUE " +
                         "/r[un]f[irstafterupdatefoldername] VALUE /fu[nctionsfoldername] VALUE /v[ie]w[sfoldername] VALUE " +

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -53,6 +53,8 @@
 
         public string RepositoryPath { get; set; }
 
+        public string Version { get; set; }
+
         public string VersionFile { get; set; }
 
         public string VersionXPath { get; set; }

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -16,6 +16,7 @@ namespace roundhouse.consoles
         public int CommandTimeoutAdmin { get; set; }
         public string SqlFilesDirectory { get; set; }
         public string RepositoryPath { get; set; }
+        public string Version { get; set; } 
         public string VersionFile { get; set; }
         public string VersionXPath { get; set; }
         public string AlterDatabaseFolderName { get; set; }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -16,6 +16,7 @@ namespace roundhouse.infrastructure.app
         int CommandTimeoutAdmin { get; set; }
         string SqlFilesDirectory { get; set; }
         string RepositoryPath { get; set; }
+        string Version { get; set; }
         string VersionFile { get; set; }
         string VersionXPath { get; set; }
         string AlterDatabaseFolderName { get; set; }

--- a/product/roundhouse/infrastructure.app/builders/VersionResolverBuilder.cs
+++ b/product/roundhouse/infrastructure.app/builders/VersionResolverBuilder.cs
@@ -8,14 +8,23 @@ namespace roundhouse.infrastructure.app.builders
     {
         public static VersionResolver build(FileSystemAccess file_system, ConfigurationPropertyHolder configuration_property_holder)
         {
-            VersionResolver xml_version_finder = new XmlFileVersionResolver(file_system, configuration_property_holder.VersionXPath, configuration_property_holder.VersionFile);
-            VersionResolver dll_version_finder = new DllFileVersionResolver(file_system, configuration_property_holder.VersionFile);
-            VersionResolver text_version_finder = new TextVersionResolver(file_system, configuration_property_holder.VersionFile);
-            VersionResolver script_number_version_finder = new ScriptfileVersionResolver(file_system, configuration_property_holder);
+            VersionResolver commandLine_version_finder = new CommandLineVersionResolver(configuration_property_holder.Version);
 
-            IEnumerable<VersionResolver> resolvers = new List<VersionResolver> { xml_version_finder, dll_version_finder, text_version_finder, script_number_version_finder };
+            if (commandLine_version_finder.meets_criteria())
+            {
+                return commandLine_version_finder;
+            }
+            else
+            {
+                VersionResolver xml_version_finder = new XmlFileVersionResolver(file_system, configuration_property_holder.VersionXPath, configuration_property_holder.VersionFile);
+                VersionResolver dll_version_finder = new DllFileVersionResolver(file_system, configuration_property_holder.VersionFile);
+                VersionResolver text_version_finder = new TextVersionResolver(file_system, configuration_property_holder.VersionFile);
+                VersionResolver script_number_version_finder = new ScriptfileVersionResolver(file_system, configuration_property_holder);
 
-            return new ComplexVersionResolver(resolvers);
+                IEnumerable<VersionResolver> resolvers = new List<VersionResolver> { xml_version_finder, dll_version_finder, text_version_finder, script_number_version_finder };
+
+                return new ComplexVersionResolver(resolvers);
+            }
         }
     }
 }

--- a/product/roundhouse/resolvers/CommandLineVersionResolver.cs
+++ b/product/roundhouse/resolvers/CommandLineVersionResolver.cs
@@ -1,0 +1,30 @@
+﻿using roundhouse.infrastructure.logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace roundhouse.resolvers
+{
+    public sealed class CommandLineVersionResolver : VersionResolver
+    {
+        private readonly string _version;
+
+        public CommandLineVersionResolver(string version)
+        {
+            _version = version;
+        }
+        public bool meets_criteria()
+        {
+            return !string.IsNullOrEmpty(_version);
+        }
+
+        public string resolve_version()
+        {
+            Log.bound_to(this).log_an_info_event_containing(
+                " Found version {0} from command line argument.", _version);
+
+            return _version;
+        }
+    }
+}

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -130,6 +130,7 @@
     <Compile Include="parameters\AdoNetParameter.cs" />
     <Compile Include="parameters\IParameter.cs" />
     <Compile Include="Migrate.cs" />
+    <Compile Include="resolvers\CommandLineVersionResolver.cs" />
     <Compile Include="resolvers\ScriptfileVersionResolver.cs" />
     <Compile Include="resolvers\TextVersionResolver.cs" />
     <Compile Include="RoundhousEFluentNHibernateDiffingType.cs" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -76,7 +76,7 @@ namespace roundhouse.runners
 
             if (run_in_a_transaction && !database_migrator.database.supports_ddl_transactions)
             {
-                Log.bound_to(this).log_a_warning_event_containing("You asked to run in a transaction, but this dabasetype doesn't support DDL transactions.");
+                Log.bound_to(this).log_a_warning_event_containing("You asked to run in a transaction, but this databasetype doesn't support DDL transactions.");
                 if (!silent)
                 {
                     Log.bound_to(this).log_an_info_event_containing("Please press enter to continue without transaction support...");


### PR DESCRIPTION
*NB: This is the same changelist as Pull Request #135, I've just resubmitted it via it's own feature branch (originally submitted to master - I'm new to git).*

Issue #120 asks for the ability to pass the version via the command line. I had the same requirement (for use in a TeamCity CI environment) to save having to write the managed build number to a file as a separate step.

I've implemented it this PR as follows:

* Add a new Property `Value` to the configuration objects.
* Add new command line argument and description, mapped to this property.
 * `-v|-version`, Optional, but overrides version file switches when set.
* Add a new `CommandLineVersionResolver` which is constructed with this property and checks if it's null / empty.
* Updated the logic in the `VersionResolverBuilder` skip the use of the file based resolvers if the command line resolver is valid.

I've built the project via the build.bat file and tested the produced rh.exe and it works as expected:

* `-v|-version` not **set** - *existing behaviour*
* `-v|-version`  **set** -  *uses version from `-v`*
* `-v|-version` **set**, `-vf|-versionfile` **set** - *uses version from `-v`, doesn't run file checks.*

Please take a look and let me know if you've any questions or comments. I've tried to match the style of the project, but in particular my description may not be to your liking. This is my first time properly running through the github pull process etc. so if I've omitted any steps, or failed to include any required files or changes, my apologies.

Cheers,

Alexander

Closes #120 

<!---
@huboard:{"custom_state":"ready"}
-->
