### PR TITLE
Duplicate PreRelase Version in NuGet version fixed.

### DIFF
--- a/build/nugetPrepare.step
+++ b/build/nugetPrepare.step
@@ -142,7 +142,7 @@
   <target name="update_version">
     <property name="nuget.version" value="${nuget.version + '-' + version.nuget.prerelease}" if="${version.nuget.prerelease != ''}" />
     <property name="nuget.version" value="${nuget.version + '.' + pkg.build.date}" if="${version.use.build_date and version.use_semanticversioning and version.nuget.prerelease == ''}" />
-    <property name="nuget.version" value="${nuget.version + '-' + version.nuget.prerelease + '-' + pkg.build.date}" if="${version.use.build_date and version.nuget.prerelease != ''}" />
+    <property name="nuget.version" value="${nuget.version + '-' + pkg.build.date}" if="${version.use.build_date and version.nuget.prerelease != ''}" />
     <!-- version.use.build_date -->
     <echo level="Warning" message="Using ${nuget.version} as the version for the nuget package(s)." />
   </target>


### PR DESCRIPTION
The duplicate versions caused a error on build of the nuget packages.