### PR TITLE
[Enhancement] Add support for ConfigurationFile parameter

### DIFF
--- a/product/roundhouse.console/packages.config
+++ b/product/roundhouse.console/packages.config
@@ -3,6 +3,7 @@
   <package id="FluentNHibernate" version="1.3.0.733" targetFramework="net35" />
   <package id="Iesi.Collections" version="3.3.2.4000" targetFramework="net35" />
   <package id="log4net" version="2.0.0" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net35" />
   <package id="NHibernate" version="3.3.2.4000" targetFramework="net35" />
   <package id="PublishedApplications" version="2.1.0.0" targetFramework="net35" />
   <package id="structuremap" version="2.6.3" />

--- a/product/roundhouse.console/roundhouse.console.csproj
+++ b/product/roundhouse.console/roundhouse.console.csproj
@@ -82,6 +82,10 @@
       <HintPath>..\..\packages\log4net.2.0.0\lib\net35-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NHibernate.3.3.2.4000\lib\Net35\NHibernate.dll</HintPath>

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -134,7 +134,7 @@
 
         public bool DisableOutput { get; set; }
 
-		public string ConfigurationFile { get; set; }
+        public string ConfigurationFile { get; set; }
 
         #endregion
 

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -134,6 +134,8 @@
 
         public bool DisableOutput { get; set; }
 
+		public string ConfigurationFile { get; set; }
+
         #endregion
 
         public void run_the_task()

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -57,6 +57,6 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
-		public string ConfigurationFile { get; set; }
+        public string ConfigurationFile { get; set; }
 	}
 }

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -57,5 +57,6 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
-    }
+		public string ConfigurationFile { get; set; }
+	}
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -57,5 +57,7 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
-    }
+
+		string ConfigurationFile { get; set; }
+	}
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -57,7 +57,6 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
-
-		string ConfigurationFile { get; set; }
+        string ConfigurationFile { get; set; }
 	}
 }

--- a/product/roundhouse/infrastructure/commandline.options/Options.cs
+++ b/product/roundhouse/infrastructure/commandline.options/Options.cs
@@ -760,7 +760,7 @@ namespace roundhouse.infrastructure.commandline.options {
 		private readonly Regex ValueOption = new Regex (
 			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
-		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
+		public bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
 		{
 			if (argument == null)
 				throw new ArgumentNullException ("argument");


### PR DESCRIPTION
This change introduces a new command line parameter called ConfigurationFile (or configfile or cf), which can point to a simple JSON file.

If the path to a configuration file is provided, it will read properties from the JSON file, and if they match the available configuration values (in ConfigurationPropertyHolder interface), will will copy those values in to the configuration.

If a value does not exist in the configuration file, it will use the default or provided command line value.

If a value exists in the configuration value that does not exist in the ConfigurationPropertyHolder interface, it will be ignored.  

If a value exists but cannot be converted to the correct type (via Convert.ChangeType), it will display an error message.

This JSON works:

``` json
{
    DatabaseName: "TestConfigFile",
    ServerName: "(local)",
    ThisFieldWillBeIgnored: false,
}
```

This JSON will cause a conversion error indicating that "kabook" cannot be converted to a Boolean value for the Restore field:

``` json
{
    DatabaseName: "TestConfigFile",
    ServerName: "(local)",
    ThisFieldWillBeIgnored: false,
    Restore: "kaboom"
}
```

<!---
@huboard:{"milestone_order":150.0,"order":150.0,"custom_state":""}
-->
