### PR TITLE
Schema bound views support

### DIFF
--- a/db/SQLServer/TestRoundhousE/views/vw_SchemaBound.sql
+++ b/db/SQLServer/TestRoundhousE/views/vw_SchemaBound.sql
@@ -1,0 +1,15 @@
+DECLARE @Name VarChar(100)
+DECLARE @Type VarChar(20)
+SET @Name = 'vw_SchemaBound'
+SET @Type = 'VIEW'
+IF NOT EXISTS(SELECT * FROM dbo.sysobjects WHERE [name] = @Name)
+  BEGIN
+	DECLARE @SQL varchar(1000)
+	SET @SQL = 'CREATE ' + @Type + ' ' + @Name + ' AS SELECT * FROM sysobjects'
+	EXECUTE(@SQL)
+  END
+Print 'Updating ' + @Type + ' ' + @Name
+GO
+
+ALTER VIEW dbo.vw_SchemaBound WITH SCHEMABINDING AS
+SELECT  ID FROM dbo.vw_UsedBySchemaBound

--- a/db/SQLServer/TestRoundhousE/views/vw__UsedBySchemaBound.sql
+++ b/db/SQLServer/TestRoundhousE/views/vw__UsedBySchemaBound.sql
@@ -1,0 +1,16 @@
+DECLARE @Name VarChar(100)
+DECLARE @Type VarChar(20)
+SET @Name = 'vw_UsedBySchemaBound'
+SET @Type = 'VIEW'
+IF NOT EXISTS(SELECT * FROM dbo.sysobjects WHERE [name] = @Name)
+  BEGIN
+	DECLARE @SQL varchar(1000)
+	SET @SQL = 'CREATE ' + @Type + ' ' + @Name + ' AS SELECT * FROM sysobjects'
+	EXECUTE(@SQL)
+  END
+Print 'Updating ' + @Type + ' ' + @Name
+GO
+
+ALTER VIEW dbo.vw_UsedBySchemaBound WITH SCHEMABINDING AS
+
+SELECT ID, Dude FROM dbo.Timmy

--- a/product/roundhouse.databases.access/AccessDatabase.cs
+++ b/product/roundhouse.databases.access/AccessDatabase.cs
@@ -126,5 +126,10 @@ namespace roundhouse.databases.access
         {
             return string.Empty;
         }
+
+        public override string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse.databases.mysql/MySqlDatabase.cs
+++ b/product/roundhouse.databases.mysql/MySqlDatabase.cs
@@ -128,5 +128,10 @@ namespace roundhouse.databases.mysql
         {
             throw new NotImplementedException();
         }
+
+        public override string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse.databases.oracle/OracleDatabase.cs
+++ b/product/roundhouse.databases.oracle/OracleDatabase.cs
@@ -264,5 +264,10 @@ namespace roundhouse.databases.oracle
                 END;",
             database_name.to_upper());
         }
+
+        public override string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse.databases.postgresql/PostgreSQLDatabase.cs
+++ b/product/roundhouse.databases.postgresql/PostgreSQLDatabase.cs
@@ -134,6 +134,11 @@ namespace roundhouse.databases.postgresql
             return string.Format(@"DROP DATABASE IF EXISTS {0};", database_name);
         }
 
+        public override string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
+
         public override void create_or_update_roundhouse_tables()
         {
             //Log.bound_to(this).log_an_info_event_containing("Creating schema [{0}].", roundhouse_schema_name);

--- a/product/roundhouse.databases.sqlite/SqliteDatabase.cs
+++ b/product/roundhouse.databases.sqlite/SqliteDatabase.cs
@@ -129,5 +129,10 @@
         {
             throw new NotImplementedException();
         }
+
+        public override string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -161,7 +161,8 @@ namespace roundhouse.databases.sqlserver
 	                    EXECUTE(@SQL)
                       END
                     Print 'Updating ' + @Type + ' ' + @Name
-                    GO", object_type, object_name);
+                    GO 
+                ", object_type, object_name);
         }
 
         public override string set_recovery_mode_script(bool simple)

--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -21,7 +21,7 @@ namespace roundhouse.databases.sqlserver
                 const string strings = @"(?<KEEP1>'[^']*')";
                 const string dashComments = @"(?<KEEP1>--.*$)";
                 const string starComments = @"(?<KEEP1>/\*[\S\s]*?\*/)";
-                const string separator = @"(?<KEEP1>\s)(?<BATCHSPLITTER>GO)(?<KEEP2>\s|$)";
+                const string separator = @"(?<KEEP1>\s)?(?<BATCHSPLITTER>\bGO)(?!\n)(?<KEEP2>\s|$)";
                 return strings + "|" + dashComments + "|" + starComments + "|" + separator;
             }
         }

--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -147,6 +147,23 @@ namespace roundhouse.databases.sqlserver
             //                            ALTER DATABASE [{0}] MODIFY FILE ( NAME = N'{0}', FILEGROWTH = 10240KB )
         }
 
+        public override string create_object_script(string object_type, string object_name)
+        {
+            return string.Format(
+                @"DECLARE @Name VarChar(100)
+                    DECLARE @Type VarChar(20)
+                    SET @Name = '{1}'
+                    SET @Type = '{0}'
+                    IF NOT EXISTS(SELECT * FROM dbo.sysobjects WHERE [name] = @Name)
+                      BEGIN
+	                    DECLARE @SQL varchar(1000)
+	                    SET @SQL = 'CREATE ' + @Type + ' ' + @Name + ' AS SELECT * FROM sysobjects'
+	                    EXECUTE(@SQL)
+                      END
+                    Print 'Updating ' + @Type + ' ' + @Name
+                    GO", object_type, object_name);
+        }
+
         public override string set_recovery_mode_script(bool simple)
         {
             return string.Format(

--- a/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
@@ -170,7 +170,8 @@ namespace roundhouse.databases.sqlserver2000
 	                    EXECUTE(@SQL)
                       END
                     Print 'Updating ' + @Type + ' ' + @Name
-                    GO", object_type, object_name);
+                    GO 
+                ", object_type, object_name);
         }
     }
 }

--- a/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
@@ -155,5 +155,22 @@ namespace roundhouse.databases.sqlserver2000
                         END",
                 database_name);
         }
+
+        public override string create_object_script(string object_type, string object_name)
+        {
+            return string.Format(
+                @"DECLARE @Name VarChar(100)
+                    DECLARE @Type VarChar(20)
+                    SET @Name = '{1}'
+                    SET @Type = '{0}'
+                    IF NOT EXISTS(SELECT * FROM dbo.sysobjects WHERE [name] = @Name)
+                      BEGIN
+	                    DECLARE @SQL varchar(1000)
+	                    SET @SQL = 'CREATE ' + @Type + ' ' + @Name + ' AS SELECT * FROM sysobjects'
+	                    EXECUTE(@SQL)
+                      END
+                    Print 'Updating ' + @Type + ' ' + @Name
+                    GO", object_type, object_name);
+        }
     }
 }

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -134,6 +134,8 @@
 
         public bool DisableOutput { get; set; }
 
+        public bool UsingVSDBProjectScripts { get; set; }
+
         #endregion
 
         public void run_the_task()

--- a/product/roundhouse.tests.integration/MigrateSpecs.cs
+++ b/product/roundhouse.tests.integration/MigrateSpecs.cs
@@ -7,13 +7,14 @@ namespace roundhouse.tests.integration.databases
     using roundhouse.databases.mysql;
     using roundhouse.infrastructure.logging;
     using roundhouse.infrastructure.logging.custom;
+using System;
 
     public class MigrateSpecs
     {
         public abstract class concern_for_Migrate : observations_for_a_static_sut
         {
             protected static string database_name = "TestRoundhousE";
-            protected static string sql_files_folder = @"..\..\..\..\db\SqlServer\TestRoundhousE";
+            protected static string sql_files_folder = Environment.CurrentDirectory + @"\db\SqlServer\TestRoundhousE";
 
             private after_all_observations after = () =>
             {

--- a/product/roundhouse.tests.integration/databases/SqlServerDatabaseSpecs.cs
+++ b/product/roundhouse.tests.integration/databases/SqlServerDatabaseSpecs.cs
@@ -15,7 +15,7 @@
         public abstract class concern_for_SqlServerDatabase : observations_for_a_static_sut
         {
             protected static string database_name = "TestRoundhousE";
-            protected static string sql_files_folder = @"..\..\..\..\db\SqlServer\TestRoundhousE";
+            protected static string sql_files_folder = System.Environment.CurrentDirectory + @"\db\SqlServer\TestRoundhousE";
 
             private after_all_observations after = () =>
                                                    {

--- a/product/roundhouse.tests/infrastructure/filesystem/WindowsFileSystemAccessSpecs.cs
+++ b/product/roundhouse.tests/infrastructure/filesystem/WindowsFileSystemAccessSpecs.cs
@@ -1,4 +1,4 @@
-using System.IO;
+ï»¿using System.IO;
 
 namespace roundhouse.tests.infrastructure.filesystem
 {
@@ -49,13 +49,13 @@ namespace roundhouse.tests.infrastructure.filesystem
             [Observation]
             public void utf8_encoded_file_should_read_correctly()
             {
-                utf8_file.should_be_equal_to("INSERT INTO [dbo].[timmy]([value]) VALUES('Gã')");
+                utf8_file.should_be_equal_to("INSERT INTO [dbo].[timmy]([value]) VALUES('GÃ£')");
             }
 
             [Observation]
             public void ansi_encoded_file_should_read_correctly()
             {
-                ansi_file.should_be_equal_to("INSERT INTO [dbo].[timmy]([value]) VALUES('Gã')");
+                ansi_file.should_be_equal_to("INSERT INTO [dbo].[timmy]([value]) VALUES('GÄƒ')");
             }
         }
     }

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -57,5 +57,6 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
+        public bool UsingVSDBProjectScripts { get; set; }
     }
 }

--- a/product/roundhouse/databases/Database.cs
+++ b/product/roundhouse/databases/Database.cs
@@ -106,6 +106,7 @@ namespace roundhouse.databases
         void insert_script_run(string script_name, string sql_to_run, string sql_to_run_hash, bool run_this_script_once, long version_id);
         void insert_script_run_error(string script_name, string sql_to_run, string sql_erroneous_part, string error_message, string repository_version, string repository_path);
 
+        string create_object_script(string object_type, string object_name);
         string get_version(string repository_path);
         long insert_version_and_get_version_id(string repository_path, string repository_version);
         bool has_run_script_already(string script_name);

--- a/product/roundhouse/databases/Database.cs
+++ b/product/roundhouse/databases/Database.cs
@@ -60,6 +60,8 @@
 // t##K#       i,                                j       
 //      ;i                                           
 
+using System.Collections.Generic;
+
 namespace roundhouse.databases
 {
     using System;
@@ -108,6 +110,8 @@ namespace roundhouse.databases
         long insert_version_and_get_version_id(string repository_path, string repository_version);
         bool has_run_script_already(string script_name);
         string get_current_script_hash(string script_name);
+        string get_object_definition(string object_name);
+        List<string> get_dependent_schemabound_views(string object_name);
         //object run_sql_scalar(string sql_to_run);
     }
 }

--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -83,6 +83,7 @@ namespace roundhouse.databases
         public abstract string set_recovery_mode_script(bool simple);
         public abstract string restore_database_script(string restore_from_path, string custom_restore_options);
         public abstract string delete_database_script();
+        public abstract string create_object_script(string object_type, string object_name);
 
         public virtual bool create_database_if_it_doesnt_exist(string custom_create_database_script)
         {

--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -404,5 +404,15 @@ namespace roundhouse.databases
                 connection.Dispose();
             }
         }
+
+        public virtual List<string> get_dependent_schemabound_views(string object_name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual string get_object_definition(string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse/databases/MockDatabase.cs
+++ b/product/roundhouse/databases/MockDatabase.cs
@@ -261,6 +261,11 @@ namespace roundhouse.databases
             return string.Empty;
         }
 
+        public string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
+
         private bool disposing = false;
         public void Dispose()
         {

--- a/product/roundhouse/databases/MockDatabase.cs
+++ b/product/roundhouse/databases/MockDatabase.cs
@@ -270,5 +270,16 @@ namespace roundhouse.databases
                 disposing = true;
             }
         }
+
+
+        public string get_object_definition(string object_name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public System.Collections.Generic.List<string> get_dependent_schemabound_views(string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse/databases/SqlServerLiteSpeedDatabase.cs
+++ b/product/roundhouse/databases/SqlServerLiteSpeedDatabase.cs
@@ -256,6 +256,10 @@ namespace roundhouse.databases
             }
         }
 
+        public string create_object_script(string object_type, string object_name)
+        {
+            throw new NotImplementedException();
+        }
 
         public string get_object_definition(string object_name)
         {

--- a/product/roundhouse/databases/SqlServerLiteSpeedDatabase.cs
+++ b/product/roundhouse/databases/SqlServerLiteSpeedDatabase.cs
@@ -255,5 +255,16 @@ namespace roundhouse.databases
                 disposing = true;
             }
         }
+
+
+        public string get_object_definition(string object_name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public System.Collections.Generic.List<string> get_dependent_schemabound_views(string object_name)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -57,5 +57,6 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
+        bool UsingVSDBProjectScripts { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure.app/schemabinding/SchemaBindResolver.cs
+++ b/product/roundhouse/infrastructure.app/schemabinding/SchemaBindResolver.cs
@@ -1,0 +1,64 @@
+﻿using roundhouse.databases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace roundhouse.infrastructure.app.schemabinding
+{
+    public class SchemaBindResolver
+    {
+        public Database database { get; private set; }
+
+        public SchemaBindResolver(Database database)
+        {
+            this.database = database;
+        }
+        
+        public string resolve(string sql_text)
+        {
+            var result = new StringBuilder();
+            Dictionary<string, string> definitions_to_restore = new Dictionary<string, string>();
+
+            var matchPattern = @"(?:alter|drop)\s+(?:view)\s+(?:\[?dbo\]?\.)?\[?(\w*\b)\]?";
+            foreach (Match match in Regex.Matches(sql_text, matchPattern, RegexOptions.IgnoreCase))
+            {
+                var objectName = match.Groups[1].Value;
+                var dependent_objects = database.get_dependent_schemabound_views(objectName);
+                if (dependent_objects.Count > 0)
+                {
+                    
+                    foreach (var dependentObject in dependent_objects)
+                    {
+                        if (!definitions_to_restore.ContainsKey(dependentObject))
+                        {
+                            var definition = database.get_object_definition(dependentObject);
+
+                            definition = Regex.Replace(definition, "create view", "alter view", RegexOptions.IgnoreCase);
+                            definitions_to_restore.Add(dependentObject, definition);
+                            definition = Regex.Replace(definition, "with schemabinding", "", RegexOptions.IgnoreCase);
+
+                            result.AppendLine("GO");
+                            result.AppendLine(string.Format("PRINT 'Removing schema binding from {0}'", dependentObject));
+                            result.AppendLine("GO");
+
+                            result.AppendLine(resolve(definition));
+                            result.AppendLine("GO");
+                        }
+                    }
+                }
+            }
+            result.AppendLine(sql_text);
+            foreach (var def in definitions_to_restore)
+            {
+                result.AppendLine("GO");
+                result.AppendLine(string.Format("PRINT 'Restoring schema binding to {0}'", def.Key));
+                result.AppendLine("GO");
+                result.AppendLine(def.Value);
+                result.AppendLine("GO");
+            }
+            return result.ToString();
+        }
+    }
+}

--- a/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
+++ b/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace roundhouse.migrators
 {
@@ -162,7 +163,7 @@ namespace roundhouse.migrators
         public bool run_sql(string sql_to_run, string script_name, bool run_this_script_once, bool run_this_script_every_time, long version_id, Environment environment, string repository_version, string repository_path, ConnectionType connection_type)
         {
             bool this_sql_ran = false;
-
+            
             if (this_is_a_one_time_script_that_has_changes_but_has_already_been_run(script_name, sql_to_run, run_this_script_once))
             {
                 if (error_on_one_time_script_changes)

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -115,6 +115,7 @@
     <Compile Include="infrastructure.app\builders\VersionResolverBuilder.cs" />
     <Compile Include="infrastructure.app\DatabaseTypeSynonyms.cs" />
     <Compile Include="infrastructure.app\persistence\NHibernateMigrationSessionFactory.cs" />
+    <Compile Include="infrastructure.app\schemabinding\SchemaBindResolver.cs" />
     <Compile Include="infrastructure\extensions\ObjectExtensions.cs" />
     <Compile Include="infrastructure\logging\custom\ConsoleLogger.cs" />
     <Compile Include="infrastructure\persistence\AuditEventListener.cs" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -339,7 +339,7 @@ namespace roundhouse.runners
             if (matchDeclaration != null)
             {
                 var replacePattern = @"(create)(\s+(?:view|function|aggregate|procedure|proc)\s+\[?\w*\b\]?\.?\[?(?:\w*\b)\]?)";
-                sql_text = Regex.Replace(sql_text, replacePattern, m => String.Format("{0}{1}", m.Groups[1], "ALTER"), RegexOptions.IgnoreCase);
+                sql_text = Regex.Replace(sql_text, replacePattern, m => String.Format("{0}{1}", "ALTER", m.Groups[2]), RegexOptions.IgnoreCase);
                 var create_object_script = this.database_migrator.database.create_object_script(objectType, objectName);
                 sql_text = create_object_script + sql_text;
             }

--- a/product/roundhouse/sqlsplitters/StatementSplitter.cs
+++ b/product/roundhouse/sqlsplitters/StatementSplitter.cs
@@ -21,7 +21,7 @@ namespace roundhouse.sqlsplitters
             {
                 if (script_has_text_to_run(sql_statement, sql_statement_separator_regex_pattern))
                 {
-                    return_sql_list.Add(sql_statement);
+                    return_sql_list.Add(sql_statement.Trim());
                 }
             }
 


### PR DESCRIPTION
In our application we have many schema bound views depends on each other. To alter that kind of view there is a need to drop binding first. Views scripts are preprocessed  and if there are dependent schema bound views, binding is dropped and after view is altered, schema binding is restored.
