### PR TITLE
Feature/user token replacement

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -10,6 +10,7 @@ using roundhouse.folders;
 using roundhouse.infrastructure;
 using roundhouse.infrastructure.app;
 using roundhouse.infrastructure.app.logging;
+using roundhouse.infrastructure.app.tokens;
 using roundhouse.infrastructure.commandline.options;
 using roundhouse.infrastructure.containers;
 using roundhouse.infrastructure.extensions;
@@ -284,6 +285,10 @@ namespace roundhouse.console
                 .Add("rcm=|recoverymode=",
                      "RecoveryMode - This instructs RH to set the database recovery mode to Simple|Full|NoChange. Defaults to NoChange.",
                      option => configuration.RecoveryMode = (RecoveryMode)Enum.Parse(typeof(RecoveryMode), option, true))
+                //user tokens
+                .Add("ut=|usertokens=",
+                    "UserTokens - This is a list of key/value pars used in scripts: the token '{{SomeToken}}' will be replace by 'value123' if 'ut=SomeToken=value123' is provide.",
+                    option => configuration.UserTokens = UserTokenParser.Parse(option))
                 //debug
                 .Add("debug",
                      "Debug - This instructs RH to write out all messages. Defaults to false.",

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -13,6 +13,7 @@
     using resolvers;
     using runners;
     using Environment = environments.Environment;
+    using System.Collections.Generic;
 
     public sealed class Roundhouse : ITask, ConfigurationPropertyHolder
     {
@@ -137,6 +138,8 @@
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
 
         public bool DisableOutput { get; set; }
+
+        public Dictionary<string, string> UserTokens { get; set; }
 
         #endregion
 

--- a/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
@@ -22,7 +22,15 @@ namespace roundhouse.tests.infrastructure.app.tokens
 
             context c = () =>
             {
-                configuration = new DefaultConfiguration { DatabaseName = database_name };
+                configuration = new DefaultConfiguration 
+                { 
+                    DatabaseName = database_name,
+                    UserTokens = new Dictionary<string, string>()
+                    {
+                        { "UserId", "123" },
+                        { "UserName", "Some Name" }
+                    }
+                };
             };
         }
 
@@ -79,30 +87,9 @@ namespace roundhouse.tests.infrastructure.app.tokens
             {
                 TokenReplacer.replace_tokens(configuration, "ALTER DATABASE {{DataBase}}").should_be_equal_to("ALTER DATABASE {{DataBase}}");
             }
-        }
-
-        [Concern(typeof (TokenReplacer))]
-        public class when_replacing_tokens_in_sql_files_using_user_tokens_from_configuration
-        {
-            protected static object result;
-            protected static ConfigurationPropertyHolder configuration;
-
-            context c = () =>
-            {
-                configuration = new DefaultConfiguration
-                {
-                    UserTokens = new Dictionary<string, string>()
-                    {
-                        { "UserId", "123" },
-                        { "UserName", "Some Name" }
-                    }
-                };
-            };
-
-            because b = () => { };
 
             [Observation]
-            public void if_given_bracket_bracket_DatabaseName_bracket_bracket_should_replace_with_the_DatabaseName_from_the_configuration()
+            public void if_given_userid_and_username_should_replace_with_the_user_tokens_from_the_configuration()
             {
                 TokenReplacer.replace_tokens(configuration, "SELECT * FROM Users WHERE UserId = {{UserId}} OR UserName = '{{UserName}}'")
                     .should_be_equal_to("SELECT * FROM Users WHERE UserId = "+configuration.UserTokens["UserId"]+" OR UserName = '"+configuration.UserTokens["UserName"]+"'");

--- a/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using bdddoc.core;
 using developwithpassion.bdd.contexts;
 using developwithpassion.bdd.mbunit;
@@ -79,5 +80,34 @@ namespace roundhouse.tests.infrastructure.app.tokens
                 TokenReplacer.replace_tokens(configuration, "ALTER DATABASE {{DataBase}}").should_be_equal_to("ALTER DATABASE {{DataBase}}");
             }
         }
+
+        [Concern(typeof (TokenReplacer))]
+        public class when_replacing_tokens_in_sql_files_using_user_tokens_from_configuration
+        {
+            protected static object result;
+            protected static ConfigurationPropertyHolder configuration;
+
+            context c = () =>
+            {
+                configuration = new DefaultConfiguration
+                {
+                    UserTokens = new Dictionary<string, string>()
+                    {
+                        { "UserId", "123" },
+                        { "UserName", "Some Name" }
+                    }
+                };
+            };
+
+            because b = () => { };
+
+            [Observation]
+            public void if_given_bracket_bracket_DatabaseName_bracket_bracket_should_replace_with_the_DatabaseName_from_the_configuration()
+            {
+                TokenReplacer.replace_tokens(configuration, "SELECT * FROM Users WHERE UserId = {{UserId}} OR UserName = '{{UserName}}'")
+                    .should_be_equal_to("SELECT * FROM Users WHERE UserId = "+configuration.UserTokens["UserId"]+" OR UserName = '"+configuration.UserTokens["UserName"]+"'");
+            }
+        }
+
     }
 }

--- a/product/roundhouse.tests/infrastructure.app/tokens/UserTokenParserSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/tokens/UserTokenParserSpecs.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using bdddoc.core;
+using developwithpassion.bdd.contexts;
+using developwithpassion.bdd.mbunit;
+using developwithpassion.bdd.mbunit.standard;
+
+namespace roundhouse.tests.infrastructure.app.tokens
+{
+    using roundhouse.infrastructure.app.tokens;
+    using System.IO;
+
+    public class UserTokenParserSpecs
+    {
+        [Concern(typeof(UserTokenParser))]
+        public class when_parsing_from_text
+        {
+            protected static object result;
+
+            context c = () =>
+            { };
+
+            [Observation]
+            public void if_given_keyvalues_should_parse_to_dictionary()
+            {
+                var dictionary = UserTokenParser.Parse("UserId=123&UserName=Some Name");
+                dictionary.should_not_be_an_instance_of<Dictionary<string, string>>();
+                dictionary.should_only_contain(
+                    new KeyValuePair<string, string>("UserId", "123"),
+                    new KeyValuePair<string, string>("UserName", "Some Name"));
+            }
+            [Observation]
+            public void if_given_filepath_with_keyvalues_should_parse_to_dictionary()
+            {
+                var filename = Guid.NewGuid().ToString("N") + ".txt";
+                File.WriteAllText(filename, "UserId=123&UserName=Some Name");
+                try
+                {
+                    var dictionary = UserTokenParser.Parse(filename);
+                    dictionary.should_not_be_an_instance_of<Dictionary<string, string>>();
+                    dictionary.should_only_contain(
+                        new KeyValuePair<string, string>("UserId", "123"),
+                        new KeyValuePair<string, string>("UserName", "Some Name"));
+                }
+                finally 
+                {
+                    File.Delete(filename);
+                }
+            }
+            [Observation]
+            public void if_given_wrong_syntax_text_without_equals_sign_should_throw_format_exception()
+            {
+                Action action = () =>
+                {
+                    var dictionary = UserTokenParser.Parse("UserId123User&NameSome Name");
+                };
+                action.should_throw_an<FormatException>();
+            }
+            [Observation]
+            public void if_given_empty_text_should_throw_argument_null_exception()
+            {
+                Action action = () =>
+                {
+                    var dictionary = UserTokenParser.Parse("");
+                };
+                action.should_throw_an<ArgumentNullException>();
+            }
+        }
+
+    }
+}

--- a/product/roundhouse.tests/infrastructure.app/tokens/UserTokenParserSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/tokens/UserTokenParserSpecs.cs
@@ -21,19 +21,10 @@ namespace roundhouse.tests.infrastructure.app.tokens
             { };
 
             [Observation]
-            public void if_given_keyvalues_should_parse_to_dictionary()
-            {
-                var dictionary = UserTokenParser.Parse("UserId=123&UserName=Some Name");
-                dictionary.should_not_be_an_instance_of<Dictionary<string, string>>();
-                dictionary.should_only_contain(
-                    new KeyValuePair<string, string>("UserId", "123"),
-                    new KeyValuePair<string, string>("UserName", "Some Name"));
-            }
-            [Observation]
             public void if_given_filepath_with_keyvalues_should_parse_to_dictionary()
             {
                 var filename = Guid.NewGuid().ToString("N") + ".txt";
-                File.WriteAllText(filename, "UserId=123&UserName=Some Name");
+                File.WriteAllText(filename, "UserId=123" + Environment.NewLine + "UserName=Some Name");
                 try
                 {
                     var dictionary = UserTokenParser.Parse(filename);
@@ -46,15 +37,6 @@ namespace roundhouse.tests.infrastructure.app.tokens
                 {
                     File.Delete(filename);
                 }
-            }
-            [Observation]
-            public void if_given_wrong_syntax_text_without_equals_sign_should_throw_format_exception()
-            {
-                Action action = () =>
-                {
-                    var dictionary = UserTokenParser.Parse("UserId123User&NameSome Name");
-                };
-                action.should_throw_an<FormatException>();
             }
             [Observation]
             public void if_given_empty_text_should_throw_argument_null_exception()

--- a/product/roundhouse.tests/roundhouse.tests.csproj
+++ b/product/roundhouse.tests/roundhouse.tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="EmptyTestContainer.cs" />
     <Compile Include="cryptography\CryptographicServiceSpecs.cs" />
     <Compile Include="infrastructure.app\tokens\TokenReplacerSpecs.cs" />
+    <Compile Include="infrastructure.app\tokens\UserTokenParserSpecs.cs" />
     <Compile Include="infrastructure\containers\ContainerSpecs.cs" />
     <Compile Include="infrastructure\containers\custom\StructureMapContainerSpecs.cs" />
     <Compile Include="infrastructure\extensions\IterationSpecs.cs" />
@@ -160,7 +161,9 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="infrastructure\filesystem\ansiencoded.txt">

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -4,6 +4,7 @@ namespace roundhouse.consoles
     using databases;
     using infrastructure.app;
     using infrastructure.logging;
+    using System.Collections.Generic;
 
     public sealed class DefaultConfiguration : ConfigurationPropertyHolder
     {
@@ -59,5 +60,6 @@ namespace roundhouse.consoles
         public bool DisableTokenReplacement { get; set; }
         public bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         public bool DisableOutput { get; set; }
+        public Dictionary<string, string> UserTokens { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -4,6 +4,7 @@ namespace roundhouse.infrastructure.app
 {
     using System;
     using databases;
+    using System.Collections.Generic;
 
     public interface ConfigurationPropertyHolder
     {
@@ -59,5 +60,6 @@ namespace roundhouse.infrastructure.app
         bool DisableTokenReplacement { get; set; }
         bool SearchAllSubdirectoriesInsteadOfTraverse { get; set; }
         bool DisableOutput { get; set; }
+        Dictionary<string, string> UserTokens { get; set; }
     }
 }

--- a/product/roundhouse/infrastructure.app/tokens/TokenReplacer.cs
+++ b/product/roundhouse/infrastructure.app/tokens/TokenReplacer.cs
@@ -1,3 +1,5 @@
+using log4net.Layout;
+
 namespace roundhouse.infrastructure.app.tokens
 {
     using System;
@@ -36,7 +38,16 @@ namespace roundhouse.infrastructure.app.tokens
             Dictionary<string, string> property_dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var property in configuration.GetType().GetProperties())
             {
-                property_dictionary.Add(property.Name, property.GetValue(configuration, null).to_string());
+                if (property.Name == "UserTokens")
+                {
+                    var userTokens = property.GetValue(configuration, null) as Dictionary<string, string>;
+                    if (userTokens != null)
+                        foreach (var userToken in userTokens)
+                        {
+                            property_dictionary[userToken.Key] = userToken.Value;
+                        }
+                }
+                else property_dictionary.Add(property.Name, property.GetValue(configuration, null).to_string());
             }
 
             return property_dictionary;

--- a/product/roundhouse/infrastructure.app/tokens/UserTokenParser.cs
+++ b/product/roundhouse/infrastructure.app/tokens/UserTokenParser.cs
@@ -1,0 +1,30 @@
+﻿
+namespace roundhouse.infrastructure.app.tokens
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    public class UserTokenParser
+    {
+        public static Dictionary<string, string> Parse(string option)
+        {
+            if (String.IsNullOrEmpty(option)) throw new ArgumentNullException("option");
+            
+            var textToParse = option;
+            var pairs = textToParse.Split(new string[] { "&" }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (pairs.Length == 1 && File.Exists(textToParse))
+            {
+                textToParse = File.ReadAllText(textToParse);
+                pairs = textToParse.Split(new string[] { "&" }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            
+            if (pairs.Any(p => !p.Contains("="))) throw new FormatException("Wrong format");
+
+            return pairs.ToDictionary(p => p.Split(new string[] {"="}, StringSplitOptions.RemoveEmptyEntries)[0],
+                p => p.Split(new string[] {"="}, StringSplitOptions.RemoveEmptyEntries)[1]);
+        }
+    }
+}

--- a/product/roundhouse/infrastructure.app/tokens/UserTokenParser.cs
+++ b/product/roundhouse/infrastructure.app/tokens/UserTokenParser.cs
@@ -11,20 +11,22 @@ namespace roundhouse.infrastructure.app.tokens
         public static Dictionary<string, string> Parse(string option)
         {
             if (String.IsNullOrEmpty(option)) throw new ArgumentNullException("option");
-            
-            var textToParse = option;
-            var pairs = textToParse.Split(new string[] { "&" }, StringSplitOptions.RemoveEmptyEntries);
 
-            if (pairs.Length == 1 && File.Exists(textToParse))
+            if (!File.Exists(option)) throw new FileNotFoundException("File not found", option);
+
+            var dictionary = new Dictionary<string, string>();
+            using (var reader = File.OpenText(option))
             {
-                textToParse = File.ReadAllText(textToParse);
-                pairs = textToParse.Split(new string[] { "&" }, StringSplitOptions.RemoveEmptyEntries);
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if(String.IsNullOrEmpty(line)) continue;
+                    var keyvalue = line.Split(new string[] { "=" }, StringSplitOptions.RemoveEmptyEntries);
+                    if(keyvalue.Length != 2) continue;
+                    dictionary[keyvalue[0]] = keyvalue[1];
+                }
             }
-            
-            if (pairs.Any(p => !p.Contains("="))) throw new FormatException("Wrong format");
-
-            return pairs.ToDictionary(p => p.Split(new string[] {"="}, StringSplitOptions.RemoveEmptyEntries)[0],
-                p => p.Split(new string[] {"="}, StringSplitOptions.RemoveEmptyEntries)[1]);
+            return dictionary;
         }
     }
 }

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -115,6 +115,7 @@
     <Compile Include="infrastructure.app\builders\VersionResolverBuilder.cs" />
     <Compile Include="infrastructure.app\DatabaseTypeSynonyms.cs" />
     <Compile Include="infrastructure.app\persistence\NHibernateMigrationSessionFactory.cs" />
+    <Compile Include="infrastructure.app\tokens\UserTokenParser.cs" />
     <Compile Include="infrastructure\extensions\ObjectExtensions.cs" />
     <Compile Include="infrastructure\logging\custom\ConsoleLogger.cs" />
     <Compile Include="infrastructure\persistence\AuditEventListener.cs" />


### PR DESCRIPTION
I need a simple user token replacement:
- added new argument "ut=|usertokens="
- receive a path to a file which content follow the syntax:

```
UserId=123
UserName=Some Name
```
- parse the file content to a Dictionary<string, string> into ConfigurationPropertyHolder.UserTokens
- when creating a dictionary from configuration in TokenReplacer.create_dictionary_from_configuration, check for the property UserTokens and add all properties to the final dictionary

I couldn't be able to run my new tests through test.bat. Is there any place explaining how to add more unit tests?

Closes #140
