### PR TITLE
Fixed "Cannot access a disposed object. Object name: 'NpgsqlConnection'....

### DIFF
--- a/product/roundhouse/databases/AdoNetDatabase.cs
+++ b/product/roundhouse/databases/AdoNetDatabase.cs
@@ -53,6 +53,7 @@ namespace roundhouse.databases
                 admin_connection.clear_pool();
                 admin_connection.close();
                 admin_connection.Dispose();
+                admin_connection = null;
             }
 
         }
@@ -92,6 +93,7 @@ namespace roundhouse.databases
                 server_connection.clear_pool();
                 server_connection.close();
                 server_connection.Dispose();
+                server_connection = null;
             }
         }
 


### PR DESCRIPTION
Running the sample migrations for PostgreSQL the following exception was encountered when all scripts were successfully applied:

Cannot access a disposed object.
Object name: 'NpgsqlConnection'.
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'NpgsqlConnection'.
   at Npgsql.NpgsqlConnection.CheckNotDisposed()
   at Npgsql.NpgsqlConnection.get_FullState()
   at Npgsql.NpgsqlConnection.get_State()
   at roundhouse.databases.DefaultDatabase`1.dispose_connection(IConnection`1 connection)
   at roundhouse.databases.DefaultDatabase`1.Dispose()
   at roundhouse.runners.RoundhouseMigrationRunner.run()
   at roundhouse.console.Program.run_migrator(ConfigurationPropertyHolder configuration)
   at roundhouse.console.Program.Main(String[] args)

Apparently, there was a try to dispose a connection, which was already previously disposed within the call to close the same connection.
