### PR TITLE
Use a "natural" sort order when enumerating the scripts to execute

### DIFF
--- a/product/roundhouse.tests/infrastructure/NaturalStringComparerSpecs.cs
+++ b/product/roundhouse.tests/infrastructure/NaturalStringComparerSpecs.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+namespace roundhouse.tests.infrastructure
+{
+    using roundhouse.infrastructure;
+    using bdddoc.core;
+    using developwithpassion.bdd.contexts;
+    using developwithpassion.bdd.mbunit;
+    using developwithpassion.bdd.mbunit.standard;
+    using developwithpassion.bdd.mbunit.standard.observations;
+
+    public class NaturalStringComparerSpecs
+    {
+        public abstract class concern_for_comparer : observations_for_a_sut_with_a_contract<IComparer<string>, NaturalStringComparer>
+        {
+            protected static object result;
+
+            context c = () => { };
+        }
+
+        [Concern(typeof(NaturalStringComparer))]
+        public class when_sorting : concern_for_comparer
+        {
+            private const string zeroOne = "001_Foo";
+            private const string zeroTwo = "002_Foo";
+            private const string zeroThree = "003_Foo";
+            private const string zeroFour = "004_Foo";
+            private const string zeroTen = "010_Foo";
+            private const string zeroEleven = "011_Foo";
+            private const string zeroTwelve = "012_Foo";
+            private const string zeroThirteen = "013_Foo";
+
+            private const string one = "1_Foo";
+            private const string two = "2_Foo";
+            private const string three = "3_Foo";
+            private const string four = "4_Foo";
+            private const string ten = "10_Foo";
+            private const string eleven = "11_Foo";
+            private const string twelve = "12_Foo";
+            private const string thirteen = "13_Foo";
+
+            [Observation]
+            public void simple_example_should_sort_correctly()
+            {
+                string unsorted = "egadfcb";
+                string sortedExpected = "abcdefg";
+                string sortedActual = new string(unsorted.OrderBy(x => x.ToString(), new NaturalStringComparer()).ToArray());
+                sortedActual.should_be_equal_to(sortedExpected);
+            }
+
+            [Observation]
+            public void zero_padded_numbers_should_sort_correctly()
+            {
+                string[] unsorted = new[] { zeroOne, zeroTen, zeroEleven, zeroTwo, zeroThree };
+                string[] sortedExpected = new[] { zeroOne, zeroTwo, zeroThree, zeroTen, zeroEleven };
+                string[] sortedActual = unsorted.OrderBy(x => x, new NaturalStringComparer()).ToArray();
+                sortedActual.should_be_equal_to(sortedExpected);
+            }
+
+            [Observation]
+            public void unpadded_numbers_should_sort_correctly()
+            {
+                string[] unsorted = new[] { one, ten, eleven, two, three };
+                string[] sortedExpected = new[] { one, two, three, ten, eleven };
+                string[] sortedActual = unsorted.OrderBy(x => x, new NaturalStringComparer()).ToArray();
+                sortedActual.should_be_equal_to(sortedExpected);
+            }
+
+            [Observation]
+            public void mixture_of_zero_padded_and_unpadded_numbers_should_sort_correctly()
+            {
+                string[] unsorted = new[] { four, eleven, thirteen, zeroOne, zeroThree, two, zeroTen, zeroTwelve };
+                string[] sortedExpected = new[] { zeroOne, two, zeroThree, four, zeroTen, eleven, zeroTwelve, thirteen };
+                string[] sortedActual = unsorted.OrderBy(x => x, new NaturalStringComparer()).ToArray();
+                sortedActual.should_be_equal_to(sortedExpected);
+            }
+        }
+    }
+}

--- a/product/roundhouse.tests/roundhouse.tests.csproj
+++ b/product/roundhouse.tests/roundhouse.tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="infrastructure\logging\custom\Log4NetLogFactorySpecs.cs" />
     <Compile Include="infrastructure\logging\custom\Log4NetLoggerSpecs.cs" />
     <Compile Include="infrastructure\logging\LogSpecs.cs" />
+    <Compile Include="infrastructure\NaturalStringComparerSpecs.cs" />
     <Compile Include="migrators\DefaultDatabaseMigratorSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="infrastructure\filesystem\WindowsFileSystemAccessSpecs.cs" />

--- a/product/roundhouse/infrastructure/NaturalStringComparer.cs
+++ b/product/roundhouse/infrastructure/NaturalStringComparer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace roundhouse.infrastructure
+{
+    /// <summary>
+    /// Implements a &quot;natural&quot; sorting order.  For example,
+    /// &quot;1_Foo&quot; &lt; &quot;2_Foo&quot; &lt; &quot;10_Foo&quot;.
+    /// </summary>
+    public sealed class NaturalStringComparer : IComparer<string>
+    {
+        [DllImport("shlwapi", CharSet=CharSet.Unicode)]
+        private static extern int StrCmpLogicalW(string psz1, string psz2);
+
+        int IComparer<string>.Compare(string x, string y)
+        {
+            return StrCmpLogicalW(x, y);
+        }
+    }
+}

--- a/product/roundhouse/infrastructure/filesystem/FileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/FileSystemAccess.cs
@@ -197,7 +197,7 @@ namespace roundhouse.infrastructure.filesystem
 		/// <param name="directory">Path to the directory</param>
 		/// <param name="pattern">Pattern or extension</param>
 		/// <returns>A list of files inside of an existing directory</returns>
-		string[] get_all_file_name_strings_recurevly_in(string directory, string pattern);
+		string[] get_all_file_name_strings_recursively_in(string directory, string pattern);
 
         #endregion
 

--- a/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
@@ -357,7 +357,7 @@ namespace roundhouse.infrastructure.filesystem
         public string[] get_all_file_name_strings_in(string directory, string pattern)
         {
             string[] returnList = Directory.GetFiles(directory, pattern);
-			return returnList.OrderBy(get_file_name_from).ToArray();
+			return returnList.OrderBy(get_file_name_from, new NaturalStringComparer()).ToArray();
         }
 
 		/// <summary>
@@ -369,7 +369,7 @@ namespace roundhouse.infrastructure.filesystem
 		public string[] get_all_file_name_strings_recursively_in(string directory, string pattern)
 		{
 			string[] returnList = Directory.GetFiles(directory, pattern, SearchOption.AllDirectories);
-			return returnList.OrderBy(get_file_name_from).ToArray();
+			return returnList.OrderBy(get_file_name_from, new NaturalStringComparer()).ToArray();
 		}
 
         #endregion

--- a/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/WindowsFileSystemAccess.cs
@@ -366,7 +366,7 @@ namespace roundhouse.infrastructure.filesystem
 		/// <param name="directory">Path to the directory</param>
 		/// <param name="pattern">Pattern or extension</param>
 		/// <returns>A list of files inside of an existing directory</returns>
-		public string[] get_all_file_name_strings_recurevly_in(string directory, string pattern)
+		public string[] get_all_file_name_strings_recursively_in(string directory, string pattern)
 		{
 			string[] returnList = Directory.GetFiles(directory, pattern, SearchOption.AllDirectories);
 			return returnList.OrderBy(get_file_name_from).ToArray();

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -115,6 +115,7 @@
     <Compile Include="infrastructure.app\builders\VersionResolverBuilder.cs" />
     <Compile Include="infrastructure.app\DatabaseTypeSynonyms.cs" />
     <Compile Include="infrastructure.app\persistence\NHibernateMigrationSessionFactory.cs" />
+    <Compile Include="infrastructure\NaturalStringComparer.cs" />
     <Compile Include="infrastructure\extensions\ObjectExtensions.cs" />
     <Compile Include="infrastructure\logging\custom\ConsoleLogger.cs" />
     <Compile Include="infrastructure\persistence\AuditEventListener.cs" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -280,7 +280,7 @@ namespace roundhouse.runners
             if (!file_system.directory_exists(directory)) return;
 
             var fileNames = configuration.SearchAllSubdirectoriesInsteadOfTraverse
-                                ? file_system.get_all_file_name_strings_recurevly_in(directory, SQL_EXTENSION)
+                                ? file_system.get_all_file_name_strings_recursively_in(directory, SQL_EXTENSION)
                                 : file_system.get_all_file_name_strings_in(directory, SQL_EXTENSION);
             foreach (string sql_file in fileNames)
             {


### PR DESCRIPTION
Right now you have to zero-prefix the script names, for example
0001_Foo.sql
0002_Bar.sql
...
0010_Baz.sql

That's slightly ugly.  Worse, the limit might eventually be reached.

Using a natural sort order lets you name the scripts:
1_Foo.sql
2_Bar.sql
10_Baz.sql