### PR TITLE
Fix for bug #176: The creation of database in SQL 2000 does not work.

### DIFF
--- a/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
@@ -93,7 +93,6 @@ namespace roundhouse.databases.sqlserver2000
 
         public override string create_database_script()
         {
-            //Using global variable @@VERSION to get the information about current MS SQL Server instance.
             return string.Format(
                 @"
                         DECLARE @Created bit

--- a/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
@@ -93,15 +93,19 @@ namespace roundhouse.databases.sqlserver2000
 
         public override string create_database_script()
         {
+            //Using global variable @@VERSION to get the information about current MS SQL Server instance.
             return string.Format(
                 @"
                         DECLARE @Created bit
                         SET @Created = 0
-                        IF NOT EXISTS(SELECT * FROM sys.databases WHERE [name] = '{0}') 
-                         BEGIN 
-                            CREATE DATABASE [{0}] 
-                            SET @Created = 1
-                         END
+                        IF(PATINDEX('%Microsoft SQL Server 2000%',@@VERSION) > 0)
+                        BEGIN
+	                        IF NOT EXISTS(SELECT * FROM sysdatabases WHERE [name] = '{0}')
+	                        BEGIN 
+		                        CREATE DATABASE [{0}] 
+		                        SET @Created = 1
+	                        END
+                        END
 
                         SELECT @Created 
                         ",

--- a/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver2000/SqlServerDatabase.cs
@@ -98,14 +98,11 @@ namespace roundhouse.databases.sqlserver2000
                 @"
                         DECLARE @Created bit
                         SET @Created = 0
-                        IF(PATINDEX('%Microsoft SQL Server 2000%',@@VERSION) > 0)
-                        BEGIN
-	                        IF NOT EXISTS(SELECT * FROM sysdatabases WHERE [name] = '{0}')
-	                        BEGIN 
-		                        CREATE DATABASE [{0}] 
-		                        SET @Created = 1
-	                        END
-                        END
+                        IF NOT EXISTS(SELECT * FROM sysdatabases WHERE [name] = '{0}')
+	                    BEGIN 
+		                   CREATE DATABASE [{0}] 
+		                   SET @Created = 1
+	                    END
 
                         SELECT @Created 
                         ",


### PR DESCRIPTION
This is a PR for the bug #176 .The fix uses the function @@VERSION of SQL Server to get the information about the current MS SQL Server instance (as explained also here: http://support2.microsoft.com/default.aspx?scid=kb;en-us;321185), and the function PATINDEX (https://technet.microsoft.com/en-us/library/aa276881%28v=sql.80%29.aspx) to check the specific pattern ('Microsoft SQL Server 2000'). In case the pattern is found (then PATINDEX returns an int > 0) and the database doesn't exist, the script creates the requested database. Let me know if you have other suggestions and/or edits.

This closes #176.