### PR TITLE
Fix #192 - handle Azure Database connection strings

### DIFF
--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -12,7 +12,7 @@ namespace roundhouse.databases.sqlserver
 
     public class SqlServerDatabase : AdoNetDatabase
     {
-        private string connect_options = "Integrated Security";
+        private string connect_options = "Integrated Security=SSPI;";
 
         public override string sql_statement_separator_regex_pattern
         {
@@ -30,37 +30,9 @@ namespace roundhouse.databases.sqlserver
         {
             if (!string.IsNullOrEmpty(connection_string))
             {
-                string[] parts = connection_string.Split(';');
-                foreach (string part in parts)
-                {
-                    if (string.IsNullOrEmpty(server_name) && (part.to_lower().Contains("server") || part.to_lower().Contains("data source")))
-                    {
-                        server_name = part.Substring(part.IndexOf("=") + 1);
-                    }
-
-                    if (string.IsNullOrEmpty(database_name) && (part.to_lower().Contains("initial catalog") || part.to_lower().Contains("database")))
-                    {
-                        database_name = part.Substring(part.IndexOf("=") + 1);
-                    }
-                }
-
-                if (!connection_string.to_lower().Contains(connect_options.to_lower()))
-                {
-                    connect_options = string.Empty;
-                    foreach (string part in parts)
-                    {
-                        if (!part.to_lower().Contains("server") && !part.to_lower().Contains("data source") && !part.to_lower().Contains("initial catalog") &&
-                            !part.to_lower().Contains("database"))
-                        {
-                            connect_options += part + ";";
-                        }
-                    }
-                }
-            }
-
-            if (connect_options == "Integrated Security")
-            {
-                connect_options = "Integrated Security=SSPI;";
+                var connection_string_builder = new SqlConnectionStringBuilder(connection_string);
+                server_name = connection_string_builder.DataSource;
+                database_name = connection_string_builder.InitialCatalog;
             }
 
             if (string.IsNullOrEmpty(connection_string))

--- a/product/roundhouse.tests/databases/SqlServerDatabaseSpecs.cs
+++ b/product/roundhouse.tests/databases/SqlServerDatabaseSpecs.cs
@@ -131,5 +131,30 @@ namespace roundhouse.tests.databases
                 sut.connection_string.should_contain("(local)");
             }
         }
+
+        [Concern(typeof (SqlServerDatabase))]
+        public class when_initializing_a_connection_to_a_sql_azure_database :
+            concern_for_SqlServerDatabase
+        {
+            private because b = () =>
+            {
+                sut.connection_string =
+                    "Server=randomsymbols.database.windows.net;Database=bob;User ID=admin@randomsymbols;Password=password;Trusted_Connection=False;Encrypt=True;Connection Timeout=30;";
+                sut.initialize_connections(configuration_property_holder);
+            };
+
+            [Observation]
+            public void should_have_the_original_server_and_databse_to_connect_to()
+            {
+                sut.server_name.should_be_equal_to("randomsymbols.database.windows.net");
+                sut.database_name.should_be_equal_to("bob");
+            }
+
+            [Observation]
+            public void should_have_master_as_the_admin_database_to_connect_to()
+            {
+                sut.admin_connection_string.should_contain("master");
+            }
+        }
     }
 }


### PR DESCRIPTION
Azure Database server has name in the following format:
{randomsymbols}.database.windows.net - that "database" string occurrence
confuses code that parses connection string, making RH think that it's
a database name.

Fixed code in SqlServerDatabase that parses connection string to
retrieve server and database name. Use standard .Net
SqlConnectionStringBuilder utility for parsing instead of making
that by hand.

Note, that this code is fixed only for SqlServerDatabase, probably the similar thing should be applied to other databases as well.

This closes #192