### PR TITLE
Improve MSBuild error handling for 'RecoveryMode'

### DIFF
--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -7,16 +7,27 @@
     using infrastructure.app.logging;
     using infrastructure.containers;
     using infrastructure.filesystem;
-    using infrastructure.logging;
+
     using Microsoft.Build.Framework;
     using migrators;
+
+    using Microsoft.Build.Utilities;
+
     using resolvers;
     using runners;
     using Environment = environments.Environment;
+    using Logger = roundhouse.infrastructure.logging.Logger;
 
     public sealed class Roundhouse : ITask, ConfigurationPropertyHolder
     {
         private RecoveryMode recoveryMode;
+
+        private readonly TaskLoggingHelper loggingHelper;
+
+        public Roundhouse()
+        {
+            this.loggingHelper = new TaskLoggingHelper(this);
+        }
 
         #region MSBuild
 
@@ -30,7 +41,7 @@
         bool ITask.Execute()
         {
             run_the_task();
-            return true;
+            return !this.loggingHelper.HasLoggedErrors;
         }
 
         #endregion
@@ -148,7 +159,7 @@
                 }
                 else
                 {
-                    this.Logger.log_an_error_event_containing("The value of 'RecoveryMode' must be one of these values: 'NoChange', 'Simple' or 'Full'. Actual value was '{0}'.", value);
+                    this.loggingHelper.LogError("The value of 'RecoveryMode' must be one of these values: 'NoChange', 'Simple' or 'Full'. Actual value was '{0}'.", value);
                 }
             }
         }
@@ -176,6 +187,11 @@
 
         public void run_the_task()
         {
+            if (this.loggingHelper.HasLoggedErrors)
+            {
+                return;
+            }
+
             Log4NetAppender.configure_without_console();
             ApplicationConfiguraton.set_defaults_if_properties_are_not_set(this);
 

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -63,7 +63,7 @@
 
         public string RunAfterCreateDatabaseFolderName { get; set; }
 
-		public string RunBeforeUpFolderName { get; set; }
+        public string RunBeforeUpFolderName { get; set; }
 
         public string UpFolderName { get; set; }
 
@@ -142,12 +142,14 @@
             set
             {
                 RecoveryMode result;
-                if (!Enum.TryParse(value, true, out result))
+                if (Enum.TryParse(value, true, out result))
                 {
-                    throw new ArgumentOutOfRangeException("value", value, "The value of 'RecoveryMode' must be one of these values: 'NoChange', 'Simple' or 'Full'.");
+                    this.recoveryMode = result;
                 }
-
-                this.recoveryMode = result;
+                else
+                {
+                    this.Logger.log_an_error_event_containing("The value of 'RecoveryMode' must be one of these values: 'NoChange', 'Simple' or 'Full'. Actual value was '{0}'.", value);
+                }
             }
         }
 

--- a/product/roundhouse.tasks/roundhouse.tasks.csproj
+++ b/product/roundhouse.tasks/roundhouse.tasks.csproj
@@ -82,6 +82,7 @@
     <Reference Include="Microsoft.Build.Framework">
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NHibernate.3.3.2.4000\lib\Net35\NHibernate.dll</HintPath>


### PR DESCRIPTION
This PR adds a reference to Microsoft.Build.Utilities.v4.0 for its `TaskLoggingHelper` class.

Code that previously threw `ArgumentOutOfRangeException` now instead log an MSBuild error.

MSBuild errors that were logged using the `TaskLoggingHelper` now cause the Roundhouse task to exit early and crash the build script (unless `ContinueOnError=true`).