### PR TITLE
(GH-120) Pass version number in the command line

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -138,6 +138,9 @@ namespace roundhouse.console
                      string.Format(
                          "RepositoryPath - The repository. A string that can be anything. Used to track versioning along with the version. Defaults to null."),
                      option => configuration.RepositoryPath = option)
+                .Add("v=|version=",
+                     "Version - Specify the version directly instead of looking in a file. If present, ignores file version options.",
+                     option => configuration.Version = option)
                 .Add("vf=|versionfile=",
                      string.Format("VersionFile - Either a .XML file, a .DLL or a .TXT file that a version can be resolved from. Defaults to \"{0}\".",
                                    ApplicationParameters.default_version_file),
@@ -339,7 +342,7 @@ namespace roundhouse.console
                         "/s[ervername] VALUE " +
                         "/c[onnection]s[tring]a[dministration] VALUE " +
                         "/c[ommand]t[imeout] VALUE /c[ommand]t[imeout]a[dmin] VALUE " +
-                        "/r[epositorypath] VALUE /v[ersion]f[ile] VALUE /v[ersion]x[path] VALUE " +
+                        "/r[epositorypath] VALUE /v[ersion] VALUE /v[ersion]f[ile] VALUE /v[ersion]x[path] VALUE " +
                         "/a[lter]d[atabasefoldername] /r[un]a[fter]c[reate]d[atabasefoldername] VALUE VALUE " +
                         "/r[un]b[eforeupfoldername] VALUE /u[pfoldername] VALUE /do[wnfoldername] VALUE " +
                         "/r[un]f[irstafterupdatefoldername] VALUE /fu[nctionsfoldername] VALUE /v[ie]w[sfoldername] VALUE " +

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -66,6 +66,8 @@
 
         public string RepositoryPath { get; set; }
 
+        public string Version { get; set; }
+
         public string VersionFile { get; set; }
 
         public string VersionXPath { get; set; }

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -16,6 +16,7 @@ namespace roundhouse.consoles
         public int CommandTimeoutAdmin { get; set; }
         public string SqlFilesDirectory { get; set; }
         public string RepositoryPath { get; set; }
+        public string Version { get; set; } 
         public string VersionFile { get; set; }
         public string VersionXPath { get; set; }
         public string AlterDatabaseFolderName { get; set; }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -16,6 +16,7 @@ namespace roundhouse.infrastructure.app
         int CommandTimeoutAdmin { get; set; }
         string SqlFilesDirectory { get; set; }
         string RepositoryPath { get; set; }
+        string Version { get; set; }
         string VersionFile { get; set; }
         string VersionXPath { get; set; }
         string AlterDatabaseFolderName { get; set; }

--- a/product/roundhouse/infrastructure.app/builders/VersionResolverBuilder.cs
+++ b/product/roundhouse/infrastructure.app/builders/VersionResolverBuilder.cs
@@ -8,14 +8,23 @@ namespace roundhouse.infrastructure.app.builders
     {
         public static VersionResolver build(FileSystemAccess file_system, ConfigurationPropertyHolder configuration_property_holder)
         {
-            VersionResolver xml_version_finder = new XmlFileVersionResolver(file_system, configuration_property_holder.VersionXPath, configuration_property_holder.VersionFile);
-            VersionResolver dll_version_finder = new DllFileVersionResolver(file_system, configuration_property_holder.VersionFile);
-            VersionResolver text_version_finder = new TextVersionResolver(file_system, configuration_property_holder.VersionFile);
-            VersionResolver script_number_version_finder = new ScriptfileVersionResolver(file_system, configuration_property_holder);
+            VersionResolver commandLine_version_finder = new CommandLineVersionResolver(configuration_property_holder.Version);
 
-            IEnumerable<VersionResolver> resolvers = new List<VersionResolver> { xml_version_finder, dll_version_finder, text_version_finder, script_number_version_finder };
+            if (commandLine_version_finder.meets_criteria())
+            {
+                return commandLine_version_finder;
+            }
+            else
+            {
+                VersionResolver xml_version_finder = new XmlFileVersionResolver(file_system, configuration_property_holder.VersionXPath, configuration_property_holder.VersionFile);
+                VersionResolver dll_version_finder = new DllFileVersionResolver(file_system, configuration_property_holder.VersionFile);
+                VersionResolver text_version_finder = new TextVersionResolver(file_system, configuration_property_holder.VersionFile);
+                VersionResolver script_number_version_finder = new ScriptfileVersionResolver(file_system, configuration_property_holder);
 
-            return new ComplexVersionResolver(resolvers);
+                IEnumerable<VersionResolver> resolvers = new List<VersionResolver> { xml_version_finder, dll_version_finder, text_version_finder, script_number_version_finder };
+
+                return new ComplexVersionResolver(resolvers);
+            }
         }
     }
 }

--- a/product/roundhouse/resolvers/CommandLineVersionResolver.cs
+++ b/product/roundhouse/resolvers/CommandLineVersionResolver.cs
@@ -1,0 +1,30 @@
+﻿using roundhouse.infrastructure.logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace roundhouse.resolvers
+{
+    public sealed class CommandLineVersionResolver : VersionResolver
+    {
+        private readonly string _version;
+
+        public CommandLineVersionResolver(string version)
+        {
+            _version = version;
+        }
+        public bool meets_criteria()
+        {
+            return !string.IsNullOrEmpty(_version);
+        }
+
+        public string resolve_version()
+        {
+            Log.bound_to(this).log_an_info_event_containing(
+                " Found version {0} from command line argument.", _version);
+
+            return _version;
+        }
+    }
+}

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -135,6 +135,7 @@
     <Compile Include="parameters\AdoNetParameter.cs" />
     <Compile Include="parameters\IParameter.cs" />
     <Compile Include="Migrate.cs" />
+    <Compile Include="resolvers\CommandLineVersionResolver.cs" />
     <Compile Include="resolvers\ScriptfileVersionResolver.cs" />
     <Compile Include="resolvers\TextVersionResolver.cs" />
     <Compile Include="RoundhousEFluentNHibernateDiffingType.cs" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -76,7 +76,7 @@ namespace roundhouse.runners
 
             if (run_in_a_transaction && !database_migrator.database.supports_ddl_transactions)
             {
-                Log.bound_to(this).log_a_warning_event_containing("You asked to run in a transaction, but this dabasetype doesn't support DDL transactions.");
+                Log.bound_to(this).log_a_warning_event_containing("You asked to run in a transaction, but this databasetype doesn't support DDL transactions.");
                 if (!silent)
                 {
                     Log.bound_to(this).log_an_info_event_containing("Please press enter to continue without transaction support...");


### PR DESCRIPTION
  - Add CommandLineVersionResolver.cs which extracts version directly from a
    string.
  - Update VersionResolverBuilder.cs to include the new resolver. Logic
    now groups the file based resolvers together and skips them if the
    command line resolver is valid.
  - Added Version property to the configuration objects.
  - Fix small typo / spelling error (already submitted in Pull Request #134