### PR TITLE
The MD5 hashing algorithm has been replaced with SHA1.

### DIFF
--- a/product/roundhouse.tests/cryptography/CryptographicServiceSpecs.cs
+++ b/product/roundhouse.tests/cryptography/CryptographicServiceSpecs.cs
@@ -15,35 +15,35 @@ namespace roundhouse.tests.cryptography
             [Test]
             public void this_is_me_learning_hashing()
             {
-                MD5 dude = MD5.Create();
+                SHA1 dude = SHA1.Create();
                 string text_to_hash = "I want to see what the freak is going on here";
                 byte[] clear_text_bytes = Encoding.UTF8.GetBytes(text_to_hash);
                 byte[] cypher_bytes = dude.ComputeHash(clear_text_bytes);
-                Assert.AreEqual(16, cypher_bytes.Length);
+                Assert.AreEqual(20, cypher_bytes.Length);
                 Debug.WriteLine(cypher_bytes);
                 string base_64_cypher = Convert.ToBase64String(cypher_bytes);
-                Assert.AreEqual(24, base_64_cypher.Length);
+                Assert.AreEqual(28, base_64_cypher.Length);
                 Debug.WriteLine(base_64_cypher);
             }
         }
 
         [TestFixture]
-        public class when_using_MD5_to_do_cryptography
+        public class when_using_SHA1_to_do_cryptography
         {
-            private CryptographicService md5_crypto;
+            private CryptographicService sha1_crypto;
 
             [SetUp]
             public void we_set_the_context()
             {
-                md5_crypto = new MD5CryptographicService();
+                sha1_crypto = new SHA1CryptographicService();
             }
 
             [Test]
             public void should_be_able_to_pass_text_and_get_back_a_base_64_hash_of_the_text()
             {
                 string text_to_hash = "I want to see what the freak is going on here";
-                string expected_hash = "TMGPZJmBhSO5uYbf/TBqNA==";
-                Assert.AreEqual(expected_hash, md5_crypto.hash(text_to_hash));
+                string expected_hash = "HD9I1wspfgyzkm6z9eZaGKhVLuA=";
+                Assert.AreEqual(expected_hash, sha1_crypto.hash(text_to_hash));
             }
         }
     }

--- a/product/roundhouse/cryptography/SHA1CryptographicService.cs
+++ b/product/roundhouse/cryptography/SHA1CryptographicService.cs
@@ -4,13 +4,13 @@ namespace roundhouse.cryptography
     using System.Security.Cryptography;
     using System.Text;
 
-    public sealed class MD5CryptographicService : CryptographicService
+    public sealed class SHA1CryptographicService : CryptographicService
     {
-        private readonly MD5 crypto_provider;
+        private readonly SHA1 crypto_provider;
 
-        public MD5CryptographicService()
+        public SHA1CryptographicService()
         {
-            crypto_provider = MD5.Create();
+            crypto_provider = SHA1.Create();
         }
 
         public string hash(string clear_text_of_what_to_hash)

--- a/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
+++ b/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
@@ -181,7 +181,7 @@ namespace roundhouse.infrastructure.app
                                             cfg.For<LogFactory>().Singleton().Use<MultipleLoggerLogFactory>();
                                             //cfg.For<Logger>().Singleton().Use(context => LogBuilder.build(context.GetInstance<FileSystemAccess>(), configuration_property_holder));
                                             cfg.For<Logger>().Use(multiLogger);
-                                            cfg.For<CryptographicService>().Singleton().Use<MD5CryptographicService>();
+                                            cfg.For<CryptographicService>().Singleton().Use<SHA1CryptographicService>();
                                             cfg.For<DatabaseMigrator>().Singleton().Use(context => new DefaultDatabaseMigrator(context.GetInstance<Database>(), context.GetInstance<CryptographicService>(), configuration_property_holder));
                                             cfg.For<VersionResolver>().Singleton().Use(
                                                 context => VersionResolverBuilder.build(context.GetInstance<FileSystemAccess>(), configuration_property_holder));

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -145,7 +145,7 @@
     <Compile Include="sqlsplitters\StatementSplitter.cs" />
     <Compile Include="consoles\DefaultConfiguration.cs" />
     <Compile Include="cryptography\CryptographicService.cs" />
-    <Compile Include="cryptography\MD5CryptographicService.cs" />
+    <Compile Include="cryptography\SHA1CryptographicService.cs" />
     <Compile Include="databases\AdoNetDatabase.cs" />
     <Compile Include="environments\DefaultEnvironment.cs" />
     <Compile Include="environments\Environment.cs" />


### PR DESCRIPTION
The MD5 hashing algorithm is not FIPS compliant. I have updated the project to use the SHA1 hashing algorithm so that it can be used where Windows has been configured to not allow MD5.
