### PR TITLE
{WIP}(GH-235) Add support for multiple environments

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -236,12 +236,12 @@ namespace roundhouse.console
                          "ScriptsRunErrorsTableName - This is the table where RH stores information about scripts that have been run with errors. Once you set this a certain way, do not change this. This is definitelly running with scissors and very sharp. Defaults to \"{0}\".",
                          ApplicationParameters.default_scripts_run_errors_table_name),
                      option => configuration.ScriptsRunErrorsTableName = option)
-                //environment
-                .Add("env=|environment=|environmentname=",
+                //environment(s)
+                .Add("env=|environment=|environmentname=|envs=|environments=|environmentnames=",
                      string.Format(
-                         "EnvironmentName - This allows RH to be environment aware and only run scripts that are in a particular environment based on the naming of the script. LOCAL.something.ENV.sql would only be run in the LOCAL environment. Defaults to \"{0}\".",
+                         "EnvironmentName(s) - This allows RH to be environment aware and only run scripts that are in a particular environment based on the naming of the script. LOCAL.something.ENV.sql would only be run in the LOCAL environment. Multiple environments may be specified as a comma-separated list. Defaults to \"{0}\".",
                          ApplicationParameters.default_environment_name),
-                     option => configuration.EnvironmentName = option)
+                     option => configuration.EnvironmentNames = option)
                 //restore
                 .Add("restore",
                      "Restore - This instructs RH to do a restore (with the restorefrompath parameter) of a database before running migration scripts. Defaults to false.",
@@ -429,7 +429,7 @@ namespace roundhouse.console
         {
             return new RoundhouseMigrationRunner(
                 configuration.RepositoryPath,
-                Container.get_an_instance_of<environments.Environment>(),
+                Container.get_an_instance_of<environments.EnvironmentSet>(),
                 Container.get_an_instance_of<KnownFolders>(),
                 Container.get_an_instance_of<FileSystemAccess>(),
                 Container.get_an_instance_of<DatabaseMigrator>(),

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -13,9 +13,9 @@
 
     using Microsoft.Build.Utilities;
 
+    using environments;
     using resolvers;
     using runners;
-    using Environment = environments.Environment;
     using Logger = roundhouse.infrastructure.logging.Logger;
 
     public sealed class Roundhouse : ITask, ConfigurationPropertyHolder
@@ -108,7 +108,10 @@
 
         public string ScriptsRunErrorsTableName { get; set; }
 
+        [Obsolete("Use EnvironmentNames")]
         public string EnvironmentName { get; set; }
+
+        public string EnvironmentNames { get; set; }
 
         public bool Restore { get; set; }
 
@@ -208,7 +211,7 @@
 
             IRunner roundhouse_runner = new RoundhouseMigrationRunner(
                 RepositoryPath,
-                Container.get_an_instance_of<Environment>(),
+                Container.get_an_instance_of<EnvironmentSet>(),
                 Container.get_an_instance_of<KnownFolders>(),
                 Container.get_an_instance_of<FileSystemAccess>(),
                 Container.get_an_instance_of<DatabaseMigrator>(),

--- a/product/roundhouse.tests/migrators/DefaultDatabaseMigratorSpecs.cs
+++ b/product/roundhouse.tests/migrators/DefaultDatabaseMigratorSpecs.cs
@@ -22,10 +22,10 @@ namespace roundhouse.tests.infrastructure.containers
         public abstract class concern_for_database_migrator : observations_for_a_sut_without_a_contract<DefaultDatabaseMigrator>
         {
             protected static object result;
-            protected static DefaultEnvironment environment;
+            protected static DefaultEnvironmentSet environment_set;
 
             context c = () => {
-                            environment = new DefaultEnvironment(new DefaultConfiguration {EnvironmentName = "TEST"});
+                            environment_set = new DefaultEnvironmentSet(new DefaultConfiguration {EnvironmentNames = "TEST"});
                         };
         }
         
@@ -37,31 +37,31 @@ namespace roundhouse.tests.infrastructure.containers
             [Observation]
             public void if_given_TEST_at_the_front_and_in_TEST_should_return_true()
             {
-                sut.this_is_an_environment_file_and_its_in_the_right_environment("TEST.something.ENV.sql", environment).should_be_true();
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("TEST.something.ENV.sql", environment_set).should_be_true();
             } 
             
             [Observation]
             public void if_given_TEST_in_the_middle_and_in_TEST_should_return_true()
             {
-                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.TEST.ENV.sql", environment).should_be_true();
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.TEST.ENV.sql", environment_set).should_be_true();
             } 
             
             [Observation]
             public void if_given_PROD_and_in_TEST_should_return_false()
             {
-                sut.this_is_an_environment_file_and_its_in_the_right_environment("PROD.something.ENV.sql", environment).should_be_false();
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("PROD.something.ENV.sql", environment_set).should_be_false();
             }
             
             [Observation]
             public void if_given_BOBTEST_at_the_front_and_in_TEST_should_return_false()
             {
-                sut.this_is_an_environment_file_and_its_in_the_right_environment("BOBTEST.something.ENV.sql", environment).should_be_false();
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("BOBTEST.something.ENV.sql", environment_set).should_be_false();
             }  
             
             [Observation]
             public void if_given_BOBTEST_in_the_middle_and_in_TEST_should_return_false()
             {
-                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.BOBTEST.ENV.sql", environment).should_be_false();
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.BOBTEST.ENV.sql", environment_set).should_be_false();
             }
         }
     
@@ -96,6 +96,87 @@ namespace roundhouse.tests.infrastructure.containers
             
         }
 
-     
+        public abstract class concern_for_database_migrator_with_multiple_environments : observations_for_a_sut_without_a_contract<DefaultDatabaseMigrator>
+        {
+            protected static object result;
+            protected static DefaultEnvironmentSet environment_set;
+
+            context c = () =>
+            {
+                environment_set = new DefaultEnvironmentSet(new DefaultConfiguration { EnvironmentNames = "TEST,SPECIAL" });
+            };
+        }
+
+        [Concern(typeof(DefaultDatabaseMigrator))]
+        public class when_determining_if_we_are_in_the_right_environment_with_multiple_environments : concern_for_database_migrator_with_multiple_environments
+        {
+            because b = () => { };
+
+            [Observation]
+            public void if_given_TEST_at_the_front_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("TEST.something.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_SPECIAL_at_the_front_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("SPECIAL.something.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_TEST_SPECIAL_at_the_front_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("TEST.SPECIAL.something.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_SPECIAL_TEST_at_the_front_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("SPECIAL.TEST.something.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_TEST_in_the_middle_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.TEST.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_SPECIAL_in_the_middle_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.SPECIAL.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_TEST_SPECIAL_in_the_middle_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.TEST.SPECIAL.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_SPECIAL_TEST_in_the_middle_and_in_TEST_SPECIAL_should_return_true()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.SPECIAL.TEST.ENV.sql", environment_set).should_be_true();
+            }
+
+            [Observation]
+            public void if_given_PROD_and_in_TEST_SPECIAL_should_return_false()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("PROD.something.ENV.sql", environment_set).should_be_false();
+            }
+
+            [Observation]
+            public void if_given_BOBTEST_at_the_front_and_in_TEST_SPECIAL_should_return_false()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("BOBTEST.something.ENV.sql", environment_set).should_be_false();
+            }
+
+            [Observation]
+            public void if_given_BOBTEST_in_the_middle_and_in_TEST_SPECIAL_should_return_false()
+            {
+                sut.this_is_an_environment_file_and_its_in_the_right_environment("something.BOBTEST.ENV.sql", environment_set).should_be_false();
+            }
+        }
     }
 }

--- a/product/roundhouse/Migrate.cs
+++ b/product/roundhouse/Migrate.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-
 namespace roundhouse
 {
     using System;
@@ -12,7 +10,7 @@ namespace roundhouse
     using migrators;
     using resolvers;
     using runners;
-    using Environment = roundhouse.environments.Environment;
+    using environments;
 
     public class Migrate
     {
@@ -59,7 +57,7 @@ namespace roundhouse
 
             RoundhouseMigrationRunner migrator = new RoundhouseMigrationRunner(
                configuration.RepositoryPath,
-               Container.get_an_instance_of<Environment>(),
+               Container.get_an_instance_of<EnvironmentSet>(),
                Container.get_an_instance_of<KnownFolders>(),
                Container.get_an_instance_of<FileSystemAccess>(),
                Container.get_an_instance_of<DatabaseMigrator>(),

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -37,7 +37,9 @@ namespace roundhouse.consoles
         public string VersionTableName { get; set; }
         public string ScriptsRunTableName { get; set; }
         public string ScriptsRunErrorsTableName { get; set; }
+        [Obsolete("Use EnvironmentNames")]
         public string EnvironmentName { get; set; }
+        public string EnvironmentNames { get; set; }
         public bool Restore { get; set; }
         public string RestoreFromPath { get; set; }
         public string RestoreCustomOptions { get; set; }

--- a/product/roundhouse/environments/DefaultEnvironment.cs
+++ b/product/roundhouse/environments/DefaultEnvironment.cs
@@ -2,20 +2,28 @@ using roundhouse.infrastructure.extensions;
 
 namespace roundhouse.environments
 {
-    using infrastructure.app;
-
     public sealed class DefaultEnvironment : Environment
     {
-        public DefaultEnvironment(ConfigurationPropertyHolder configuration)
+        public DefaultEnvironment(string environment_name)
         {
-            name = configuration.EnvironmentName;
+            name = environment_name;
         }
 
         public string name { get; private set; }
 
         public bool item_is_for_this_environment(string item_name)
         {
-            return name.to_lower() == item_name.Substring(0, item_name.IndexOf('.')).to_lower();
+            if (item_name.to_lower().StartsWith(name.to_lower() + "."))
+            {
+                return true;
+            }
+
+            if (item_name.to_lower().Contains("." + name.to_lower() + "."))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/product/roundhouse/environments/DefaultEnvironmentSet.cs
+++ b/product/roundhouse/environments/DefaultEnvironmentSet.cs
@@ -1,0 +1,25 @@
+﻿namespace roundhouse.environments
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using infrastructure.app;
+
+    public sealed class DefaultEnvironmentSet : EnvironmentSet
+    {
+        public IEnumerable<Environment> set_items { get; private set; }
+
+        public DefaultEnvironmentSet(ConfigurationPropertyHolder configuration_property_holder)
+        {
+            set_items = configuration_property_holder.EnvironmentNames
+                .Split(',')
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Select(x => new DefaultEnvironment(x.Trim()))
+                .ToList();
+        }
+
+        public bool item_is_for_this_environment_set(string item_name)
+        {
+            return set_items.Any(set_item => set_item.item_is_for_this_environment(item_name));
+        }
+    }
+}

--- a/product/roundhouse/environments/EnvironmentSet.cs
+++ b/product/roundhouse/environments/EnvironmentSet.cs
@@ -1,0 +1,10 @@
+﻿namespace roundhouse.environments
+{
+    using System.Collections.Generic;
+
+    public interface EnvironmentSet
+    {
+        IEnumerable<Environment> set_items { get; }
+        bool item_is_for_this_environment_set(string item_name);
+    }
+}

--- a/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
+++ b/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
@@ -8,7 +8,6 @@ using ILogger = Microsoft.Build.Framework.ILogger;
 
 namespace roundhouse.infrastructure.app
 {
-    using System;
     using System.IO;
     using builders;
     using containers;
@@ -16,7 +15,6 @@ namespace roundhouse.infrastructure.app
     using cryptography;
     using databases;
     using environments;
-    using extensions;
     using filesystem;
     using folders;
     using infrastructure.logging;
@@ -27,7 +25,6 @@ namespace roundhouse.infrastructure.app
     using resolvers;
     using StructureMap;
     using Container = roundhouse.infrastructure.containers.Container;
-    using Environment = roundhouse.environments.Environment;
 
     public static class ApplicationConfiguraton
     {
@@ -121,9 +118,12 @@ namespace roundhouse.infrastructure.app
             {
                 configuration_property_holder.VersionXPath = ApplicationParameters.default_version_x_path;
             }
-            if (string.IsNullOrEmpty(configuration_property_holder.EnvironmentName))
+            if (string.IsNullOrEmpty(configuration_property_holder.EnvironmentNames))
             {
-                configuration_property_holder.EnvironmentName = ApplicationParameters.default_environment_name;
+                if (!string.IsNullOrEmpty(configuration_property_holder.EnvironmentName))
+                    configuration_property_holder.EnvironmentNames = configuration_property_holder.EnvironmentName;
+                else
+                    configuration_property_holder.EnvironmentNames = ApplicationParameters.default_environment_name;
             }
             if (string.IsNullOrEmpty(configuration_property_holder.OutputPath))
             {
@@ -185,7 +185,7 @@ namespace roundhouse.infrastructure.app
                                             cfg.For<DatabaseMigrator>().Singleton().Use(context => new DefaultDatabaseMigrator(context.GetInstance<Database>(), context.GetInstance<CryptographicService>(), configuration_property_holder));
                                             cfg.For<VersionResolver>().Singleton().Use(
                                                 context => VersionResolverBuilder.build(context.GetInstance<FileSystemAccess>(), configuration_property_holder));
-                                            cfg.For<Environment>().Singleton().Use(new DefaultEnvironment(configuration_property_holder));
+                                            cfg.For<EnvironmentSet>().Singleton().Use(new DefaultEnvironmentSet(configuration_property_holder));
                                             cfg.For<Initializer>().Singleton().Use<FileSystemInitializer>();
                                         });
 

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -37,7 +37,9 @@ namespace roundhouse.infrastructure.app
         string VersionTableName { get; set; }
         string ScriptsRunTableName { get; set; }
         string ScriptsRunErrorsTableName { get; set; }
+        [Obsolete("Use EnvironmentNames")]
         string EnvironmentName { get; set; }
+        string EnvironmentNames { get; set; }
         bool Restore { get; set; }
         string RestoreFromPath { get; set; }
         string RestoreCustomOptions { get; set; }

--- a/product/roundhouse/migrators/DatabaseMigrator.cs
+++ b/product/roundhouse/migrators/DatabaseMigrator.cs
@@ -21,7 +21,7 @@ namespace roundhouse.migrators
         void run_roundhouse_support_tasks();
         string get_current_version(string repository_path);
         long version_the_database(string repository_path, string repository_version);
-        bool run_sql(string sql_to_run, string script_name, bool run_this_script_once, bool run_this_script_every_time, long version_id, Environment migrating_environment, string repository_version, string repository_path, ConnectionType connection_type);
+        bool run_sql(string sql_to_run, string script_name, bool run_this_script_once, bool run_this_script_every_time, long version_id, EnvironmentSet migrating_environment_set, string repository_version, string repository_path, ConnectionType connection_type);
         //void transfer_to_database_for_changes();
     }
 }

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -112,6 +112,8 @@
     <Compile Include="consoles\CommandExecutor.cs" />
     <Compile Include="consoles\InteractivePrompt.cs" />
     <Compile Include="databases\RecoveryMode.cs" />
+    <Compile Include="environments\DefaultEnvironmentSet.cs" />
+    <Compile Include="environments\EnvironmentSet.cs" />
     <Compile Include="infrastructure.app\ConnectionType.cs" />
     <Compile Include="databases\DefaultDatabase.cs" />
     <Compile Include="databases\MockDatabase.cs" />

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -11,12 +11,12 @@ namespace roundhouse.runners
     using infrastructure.logging;
     using migrators;
     using resolvers;
-    using Environment = environments.Environment;
+    using environments;
 
     public sealed class RoundhouseMigrationRunner : IRunner
     {
         private readonly string repository_path;
-        private readonly Environment environment;
+        private readonly EnvironmentSet environment_set;
         private readonly KnownFolders known_folders;
         private readonly FileSystemAccess file_system;
         public DatabaseMigrator database_migrator { get; private set; }
@@ -31,7 +31,7 @@ namespace roundhouse.runners
 
         public RoundhouseMigrationRunner(
             string repository_path,
-            Environment environment,
+            EnvironmentSet environment_set,
             KnownFolders known_folders,
             FileSystemAccess file_system,
             DatabaseMigrator database_migrator,
@@ -45,7 +45,7 @@ namespace roundhouse.runners
         {
             this.known_folders = known_folders;
             this.repository_path = repository_path;
-            this.environment = environment;
+            this.environment_set = environment_set;
             this.file_system = file_system;
             this.database_migrator = database_migrator;
             this.version_resolver = version_resolver;
@@ -218,7 +218,7 @@ namespace roundhouse.runners
                                                             folder.should_run_items_in_folder_every_time ? " These scripts will run every time" : string.Empty);
 
             Log.bound_to(this).log_an_info_event_containing("{0}", "-".PadRight(50, '-'));
-            traverse_files_and_run_sql(folder.folder_full_path, version_id, folder, environment, new_version, connection_type);
+            traverse_files_and_run_sql(folder.folder_full_path, version_id, folder, environment_set, new_version, connection_type);
         }
 
         public void run_out_side_of_transaction_folder(MigrationsFolder folder, long version_id, string new_version)
@@ -274,7 +274,7 @@ namespace roundhouse.runners
 
         //todo:down story
 
-        public void traverse_files_and_run_sql(string directory, long version_id, MigrationsFolder migration_folder, Environment migrating_environment,
+        public void traverse_files_and_run_sql(string directory, long version_id, MigrationsFolder migration_folder, EnvironmentSet migrating_environment_set,
                                                string repository_version, ConnectionType connection_type)
         {
             if (!file_system.directory_exists(directory)) return;
@@ -289,7 +289,7 @@ namespace roundhouse.runners
                 bool the_sql_ran = database_migrator.run_sql(sql_file_text, file_system.get_file_name_from(sql_file),
                                                              migration_folder.should_run_items_in_folder_once,
                                                              migration_folder.should_run_items_in_folder_every_time,
-                                                             version_id, migrating_environment, repository_version, repository_path, connection_type);
+                                                             version_id, migrating_environment_set, repository_version, repository_path, connection_type);
                 if (the_sql_ran)
                 {
                     try
@@ -307,7 +307,7 @@ namespace roundhouse.runners
             if (configuration.SearchAllSubdirectoriesInsteadOfTraverse) return;
             foreach (string child_directory in file_system.get_all_directory_name_strings_in(directory))
             {
-                traverse_files_and_run_sql(child_directory, version_id, migration_folder, migrating_environment, repository_version, connection_type);
+                traverse_files_and_run_sql(child_directory, version_id, migration_folder, migrating_environment_set, repository_version, connection_type);
             }
         }
 


### PR DESCRIPTION
Allows you to set multiple environments (e.g. _--environments=NEWZEALAND,CUSTOMER_).

If we have the following files:
0000 - main.sql
0001 - new zealand feature.NEWZEALAND.env.sql
0002 - australia feature.AUSTRALIA.env.sql
0003 - customer feature for any country.CUSTOMER.env.sql

Then script 0000, 0001 and 0003 will run, but not the Australia file.

Scripts are checked to see if they contain any environment from the environment set given (matching the current behaviour), remaining compatible with current use cases (i.e. https://groups.google.com/d/topic/chucknorrisframework/x2CAAWLgJ9I/discussion) and nothing needs to change for people who don't want to use multiple environments.

Three environment flags have been added to match the current 3:
Current: env, environment, environmentname
Added: envs, environments, environmentnames

Closes #235
