### PR TITLE
Provide error details when logging a warning event

### DIFF
--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -7,6 +7,7 @@ namespace roundhouse.databases
     using connections;
     using infrastructure.app;
     using infrastructure.app.tokens;
+    using infrastructure.extensions;
     using infrastructure.logging;
     using infrastructure.persistence;
     using model;
@@ -286,10 +287,10 @@ namespace roundhouse.databases
                     version = items[0].version;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Log.bound_to(this).log_a_warning_event_containing("{0} with provider {1} does not provide a facility for retrieving versions at this time.",
-                                                                  GetType(), provider);
+                Log.bound_to(this).log_a_warning_event_containing("{0} with provider {1} does not provide a facility for retrieving versions at this time.{2}{3}",
+                                                                  GetType(), provider, Environment.NewLine, ex.to_string());
             }
 
             return version;

--- a/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
+++ b/product/roundhouse/migrators/DefaultDatabaseMigrator.cs
@@ -302,9 +302,9 @@ namespace roundhouse.migrators
             {
                 old_text_hash = database.get_current_script_hash(script_name);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Log.bound_to(this).log_a_warning_event_containing("{0} - I didn't find this script executed before.", script_name);
+                Log.bound_to(this).log_a_warning_event_containing("{0} - I didn't find this script executed before.{1}{2}", script_name, System.Environment.NewLine, ex.to_string());
             }
 
             if (string.IsNullOrEmpty(old_text_hash)) return true;


### PR DESCRIPTION
Log an exception details when logging a warning event to simplify troubleshooting.

----

We've experienced following error when running RoundhousE on Azure Database:
```
2015-11-12 19:39:00,991 [WARN ] - 0001.SomeScript.sql - I didn't find this script executed before.
2015-11-12 19:39:01,929 [ERROR] - RoundhousE encountered an error.
System.Exception: 0001.SomeScript.sql has changed since the last time it was run. By default this is not allowed - scripts that run once should never change. To change this behavior to a warning, please set warnOnOneTimeScriptChanges to true and run again. Stopping execution.
   at roundhouse.migrators.DefaultDatabaseMigrator.run_sql(String sql_to_run, String script_name, Boolean run_this_script_once, Boolean run_this_script_every_time, Int64 version_id, Environment environment, String repository_version, String repository_path, ConnectionType connection_type)
   at roundhouse.runners.RoundhouseMigrationRunner.traverse_files_and_run_sql(String directory, Int64 version_id, MigrationsFolder migration_folder, Environment migrating_environment, String repository_version, ConnectionType connection_type)
   at roundhouse.runners.RoundhouseMigrationRunner.log_and_traverse(MigrationsFolder folder, Int64 version_id, String new_version, ConnectionType connection_type)
   at roundhouse.runners.RoundhouseMigrationRunner.run()
```

The script was actually present in `Roundhouse.ScriptsRun` table, but for some reason it failed to retrieve it's info (this often happens with Azure Databases). It would simplify troubleshotting if the real exception that caused the warning would be logged too.