### PR TITLE
(GH-234) Fault tolerance for transient exceptions

### DIFF
--- a/build.custom/compile.post.step
+++ b/build.custom/compile.post.step
@@ -33,6 +33,8 @@
         <include name="Npgsql.dll" />
         <include name="Mono.Security.dll" />
         <include name="System.Data.SQLite.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" />
       </fileset>
     </copy>
     <echo level="Warning" message="Copying database dlls to '${dirs.build}${path.separator}${folder.app.drop}${path.separator}_PublishedApplications${path.separator}roundhouse.console'."/>
@@ -43,6 +45,8 @@
         <include name="Npgsql.dll" />
         <include name="Mono.Security.dll" />
         <include name="System.Data.SQLite.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" />
       </fileset>
     </copy>
     <echo level="Warning" message="Copying database dlls to '${dirs.build}${path.separator}${folder.app.drop}${path.separator}_PublishedApplications${path.separator}roundhouse.tasks'."/>
@@ -53,6 +57,8 @@
         <include name="Npgsql.dll" />
         <include name="Mono.Security.dll" />
         <include name="System.Data.SQLite.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" />
       </fileset>
     </copy>
   </target>

--- a/build.custom/ilmergeDLL.build
+++ b/build.custom/ilmergeDLL.build
@@ -62,6 +62,8 @@
           <include name="${dirs.merge.from}\MySql.Data.dll" />
           <include name="${dirs.merge.from}\Npgsql.dll" />
           <include name="${dirs.merge.from}\Mono.Security.dll" />
+          <include name="${dirs.merge.from}\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" />
+          <include name="${dirs.merge.from}\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" />
         </items>
       </in>
       <do>
@@ -106,6 +108,8 @@
         <include name="Npgsql.dll" />
         <include name="Mono.Security.dll" />
         <include name="System.Data.SQLite.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" />
+        <include name="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" />
       </fileset>
     </delete>
   </target>

--- a/product/roundhouse.databases.sqlserver/TransientErrorDetectionStrategy.cs
+++ b/product/roundhouse.databases.sqlserver/TransientErrorDetectionStrategy.cs
@@ -1,0 +1,36 @@
+﻿namespace roundhouse.databases.sqlserver
+{
+    using System;
+    using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
+    using infrastructure.logging;
+
+    public class TransientErrorDetectionStrategy : ITransientErrorDetectionStrategy
+    {
+        private readonly SqlDatabaseTransientErrorDetectionStrategy inner_strategy;
+
+        public TransientErrorDetectionStrategy()
+        {
+            inner_strategy = new SqlDatabaseTransientErrorDetectionStrategy();
+        }
+
+        public bool IsTransient(Exception ex)
+        {
+            bool transient = IsTransientException(ex);
+            if (ex != null)
+            {
+                Log.bound_to(this).log_a_debug_event_containing("Checking whether the '{0}: {1}' error is transient - {2} ", ex.GetType(), ex.Message, transient);
+            }
+
+            return transient;
+        }
+
+        private bool IsTransientException(Exception ex)
+        {
+            if (ex == null)
+                return false;
+
+            // Unwrap exception to handle exceptions wrapped by NHibernate GenericAdoException
+            return inner_strategy.IsTransient(ex) || IsTransientException(ex.InnerException);
+        }
+    }
+}

--- a/product/roundhouse.databases.sqlserver/packages.config
+++ b/product/roundhouse.databases.sqlserver/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
+  <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net45" />
   <package id="FluentNHibernate" version="1.3.0.733" targetFramework="net35" />
   <package id="Iesi.Collections" version="3.3.2.4000" targetFramework="net35" />
   <package id="NHibernate" version="3.3.2.4000" targetFramework="net35" />

--- a/product/roundhouse.databases.sqlserver/roundhouse.databases.sqlserver.csproj
+++ b/product/roundhouse.databases.sqlserver/roundhouse.databases.sqlserver.csproj
@@ -75,6 +75,14 @@
     <Reference Include="Iesi.Collections, Version=1.0.1.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Iesi.Collections.3.3.2.4000\lib\Net35\Iesi.Collections.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NHibernate.3.3.2.4000\lib\Net35\NHibernate.dll</HintPath>
@@ -90,6 +98,7 @@
     <Compile Include="..\..\SolutionVersion.cs">
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="TransientErrorDetectionStrategy.cs" />
     <Compile Include="orm\ScriptsRunErrorMapping.cs" />
     <Compile Include="orm\ScriptsRunMapping.cs" />
     <Compile Include="orm\VersionMapping.cs" />

--- a/product/roundhouse/databases/AdoNetDatabase.cs
+++ b/product/roundhouse/databases/AdoNetDatabase.cs
@@ -60,15 +60,13 @@
             Log.bound_to(this).log_a_debug_event_containing("Opening connection to '{0}'", connection_string);
             server_connection = GetAdoNetConnection(connection_string);
             server_connection.open();
+
+            set_repository();
+
             if (with_transaction)
             {
                 transaction = server_connection.underlying_type().BeginTransaction();
-            }
-            
-            set_repository();
-            if (repository != null)
-            {
-                repository.start(with_transaction);
+                repository.start(true);
             }
         }
 

--- a/product/roundhouse/infrastructure/extensions/ObjectExtensions.cs
+++ b/product/roundhouse/infrastructure/extensions/ObjectExtensions.cs
@@ -1,11 +1,28 @@
 ﻿namespace roundhouse.infrastructure.extensions
 {
+    using System.Text;
+    using System.Data.SqlClient;
+
     public static class ObjectExtensions {
 
         public static string to_string(this object input)
         {
-
             if (input == null) return string.Empty;
+
+            var sqlException = input as SqlException;
+            if (sqlException != null)
+            {
+                var msg = new StringBuilder(sqlException.ToString())
+                    .AppendLine()
+                    .AppendLine("SqlErrors:");
+                
+                foreach (SqlError error in sqlException.Errors)
+                {
+                    msg.AppendFormat("Error Number: {0}, Message: {1}", error.Number, error.Message).AppendLine();
+                }
+
+                return msg.ToString();
+            }
 
             return input.ToString();
         }

--- a/product/roundhouse/packages.config
+++ b/product/roundhouse/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
+  <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net45" />
   <package id="FluentNHibernate" version="1.3.0.733" targetFramework="net35" />
   <package id="Iesi.Collections" version="3.3.2.4000" targetFramework="net35" />
   <package id="log4net" version="2.0.0" targetFramework="net35" />

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -82,6 +82,14 @@
     <Reference Include="Microsoft.Build.Framework">
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NHibernate, Version=3.3.1.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NHibernate.3.3.2.4000\lib\Net35\NHibernate.dll</HintPath>


### PR DESCRIPTION
This is to start discussion on issue #236 and to find out solution.

Added transient exception handling for SqlServer database. This is to
have a better support for Azure SQL Database where transient faults
are expected and happen periodically.

Support for transient fault handling is added in a base DefaultDatabase
class, but the retry strategy implementation is specified in a
concrete database provider (mssql in this case).

Transient faults are handled in following places:
- Transient faults when opening a connection
- Transient faults when running an update script
- Transient faults when dealing with RoundhousE internal tables (via
  NHibernate).

Microsoft TransientFaultHandling library was referenced for retry
building blocks. This might look like a dependency that could be
avoided (by just re-implementing necessary bits). It was mainly used to
utilize ReliableSqlConnection class.

As transient faults are much more common for Azure Sql Database than
for MS SQL Server, it might make sense to put retry logic into a
new dedicated Azure specific provider. But having it in a single MSSQL
provider is much more convenient from user perspective (less options to
think about) and it should not worsen experience for existing MSSQL
users.

Closes #234
