### PR TITLE
(GH-237) Increase timeout for NHibernate commands

### DIFF
--- a/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
+++ b/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
@@ -2,6 +2,7 @@ namespace roundhouse.infrastructure.persistence
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Reflection;
     using app;
     using FluentNHibernate.Cfg;
@@ -11,7 +12,6 @@ namespace roundhouse.infrastructure.persistence
     using NHibernate;
     using NHibernate.Cfg;
     using NHibernate.Event;
-    using Environment = NHibernate.Cfg.Environment;
 
     public class NHibernateSessionFactoryBuilder
     {
@@ -104,6 +104,7 @@ namespace roundhouse.infrastructure.persistence
 
                     cfg.SetListener(ListenerType.PreInsert, new AuditEventListener());
                     cfg.SetListener(ListenerType.PreUpdate, new AuditEventListener());
+                    cfg.SetProperty("command_timeout", TimeSpan.FromMinutes(5).TotalSeconds.ToString(CultureInfo.InvariantCulture));
                 })
                 .ExposeConfiguration(additional_function);
 


### PR DESCRIPTION
This is to prevent Timeout Expired exceptions when migration is running
on a slow/high latency server (the case for Azure Sql Server) or a
database with a lot of update scripts recorded in a `ScriptsRun` table.

The timeout of 5 minutes is currently hard-coded. Probably the better
way would be to add an additional configuration option. On the other
hand I'm not sure user should care about that additional config option.

Relates to #237