### PR TITLE
Log error details when failed to create database

### DIFF
--- a/product/roundhouse/databases/DefaultDatabase.cs
+++ b/product/roundhouse/databases/DefaultDatabase.cs
@@ -125,7 +125,7 @@ namespace roundhouse.databases
             {
                 Log.bound_to(this).log_a_warning_event_containing(
                     "{0} with provider {1} does not provide a facility for creating a database at this time.{2}{3}",
-                    GetType(), provider, Environment.NewLine, ex.Message);
+                    GetType(), provider, Environment.NewLine, ex.to_string());
             }
 
             return database_was_created;


### PR DESCRIPTION
This is to simplify troubleshooting when getting mysterious exceptions
from Azure like "CreateDatabaseAsyncV3 operation failed. Operation
timed out." Having exception type and stacktrace would be helpful.