### PR TITLE
Updated MySqlDatabaseConnection string to allow User Variables so SPR…

### DIFF
--- a/product/roundhouse.databases.mysql/MySqlDatabase.cs
+++ b/product/roundhouse.databases.mysql/MySqlDatabase.cs
@@ -6,6 +6,9 @@ namespace roundhouse.databases.mysql
     using infrastructure.extensions;
     using infrastructure.logging;
     using MySql.Data.MySqlClient;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Globalization;
 
     public class MySqlDatabase : AdoNetDatabase
     {
@@ -32,6 +35,14 @@ namespace roundhouse.databases.mysql
         {
             if (!string.IsNullOrEmpty(connection_string))
             {
+                // Must allow User variables for SPROCs
+                var connectionBuilder = new MySqlConnectionStringBuilder(connection_string);
+                if (!connectionBuilder.AllowUserVariables)
+                {
+                    connectionBuilder.Add("Allow User Variables", "True");
+                    connection_string = connectionBuilder.ConnectionString;
+                }
+
                 string[] parts = connection_string.Split(';');
                 foreach (string part in parts)
                 {
@@ -58,7 +69,7 @@ namespace roundhouse.databases.mysql
                 var user_name = InteractivePrompt.get_user("root", configuration_property_holder);
                 var password = InteractivePrompt.get_password("root", configuration_property_holder);
                 InteractivePrompt.write_footer();
-                
+
                 connection_string = build_connection_string(server_name, database_name, user_name, password);
             }
 
@@ -83,7 +94,14 @@ namespace roundhouse.databases.mysql
 
         private static string build_connection_string(string server_name, string database_name, string user_name, string password)
         {
-            return string.Format("Server={0};Database={1};Port=3306;Uid={2};Pwd={3};", server_name, database_name, user_name, password);
+            var connectionBuilder = new MySqlConnectionStringBuilder();
+            connectionBuilder.Server = server_name;
+            connectionBuilder.Port = 3306;
+            connectionBuilder.UserID = user_name;
+            connectionBuilder.Password = password;
+            connectionBuilder.AllowUserVariables = true; // Must allow User variables for SPROCs
+
+            return connectionBuilder.ConnectionString;
         }
 
         public override string create_database_script()
@@ -110,13 +128,41 @@ namespace roundhouse.databases.mysql
         {
             if (string.IsNullOrEmpty(sql_to_run)) return;
 
-            //TODO Investigate how pass CommandTimeout into commands which will be during MySqlScript execution.
-            var connection = connection_type == ConnectionType.Admin
-                ? admin_connection.underlying_type().downcast_to<MySqlConnection>()
-                : server_connection.underlying_type().downcast_to<MySqlConnection>();
-            
-            var script = new MySqlScript(connection, sql_to_run);
-            script.Execute();
+            try
+            {
+                string sql_mode = null;
+                // Read The sql_mode to determine ANSI_QUOTED && NO_BACKSLASH_ESCAPES
+                using (var dataReader = setup_database_command("SHOW VARIABLES", connection_type, null).ExecuteReader())
+                {
+                    while (dataReader.Read())
+                    {
+                        var variable = dataReader.GetString(0);
+                        if (variable.Equals("sql_mode", StringComparison.OrdinalIgnoreCase))
+                        {
+                            sql_mode = dataReader.GetString(1);
+                            break;
+                        }
+                    }
+                }
+
+                // Parse the Sql into statements and account for Delimiter changes                
+                var list = BreakIntoStatements(sql_to_run, sql_mode.IndexOf("ANSI_QUOTES") != -1, sql_mode.IndexOf("NO_BACKSLASH_ESCAPES") != -1);
+                foreach (var statement in list)
+                {
+                    if (string.IsNullOrEmpty(statement.text))
+                        continue;
+
+                    using (var command = setup_database_command(statement.text, connection_type, null))
+                    {
+                        command.ExecuteNonQuery();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.bound_to(this).log_a_debug_event_containing("Failure executing command. {0}{1}", Environment.NewLine, ex.ToString());
+                throw ex;
+            }
         }
 
         public override string set_recovery_mode_script(bool simple)
@@ -127,6 +173,107 @@ namespace roundhouse.databases.mysql
         public override string restore_database_script(string restore_from_path, string custom_restore_options)
         {
             throw new NotImplementedException();
+        }
+
+        // MySQLScript Helper Functions
+        string delimiter = ";";
+        private struct ScriptStatement
+        {
+            public string text;
+            public int line;
+            public int position;
+        }
+
+        private List<int> BreakScriptIntoLines(string query)
+        {
+            List<int> list = new List<int>();
+            StringReader stringReader = new StringReader(query);
+            string str = stringReader.ReadLine();
+            int num = 0;
+            for (; str != null; str = stringReader.ReadLine())
+            {
+                list.Add(num);
+                num += str.Length;
+            }
+            return list;
+        }
+
+        private List<ScriptStatement> BreakIntoStatements(string query, bool ansiQuotes, bool noBackslashEscapes)
+        {
+            string str1 = this.delimiter;
+            int num1 = 0;
+            List<ScriptStatement> list = new List<ScriptStatement>();
+            List<int> lineNumbers = this.BreakScriptIntoLines(query);
+            MySqlTokenizer tokenizer = new MySqlTokenizer(query);
+            tokenizer.AnsiQuotes = ansiQuotes;
+            tokenizer.BackslashEscapes = !noBackslashEscapes;
+            for (string str2 = tokenizer.NextToken(); str2 != null; str2 = tokenizer.NextToken())
+            {
+                if (!tokenizer.Quoted)
+                {
+                    if (str2.ToLower(CultureInfo.InvariantCulture) == "delimiter")
+                    {
+                        tokenizer.NextToken();
+                        this.AdjustDelimiterEnd(query, tokenizer);
+                        str1 = query.Substring(tokenizer.StartIndex, tokenizer.StopIndex - tokenizer.StartIndex + 1).Trim();
+                        num1 = tokenizer.StopIndex;
+                    }
+                    else
+                    {
+                        if (str1.StartsWith(str2) && tokenizer.StartIndex + str1.Length <= query.Length && query.Substring(tokenizer.StartIndex, str1.Length) == str1)
+                        {
+                            str2 = str1;
+                            tokenizer.Position = tokenizer.StartIndex + str1.Length;
+                            tokenizer.StopIndex = tokenizer.Position;
+                        }
+                        int num2 = str2.IndexOf(str1, StringComparison.InvariantCultureIgnoreCase);
+                        if (num2 != -1)
+                        {
+                            int num3 = tokenizer.StopIndex - str2.Length + num2;
+                            if (tokenizer.StopIndex == query.Length - 1)
+                                ++num3;
+                            string str3 = query.Substring(num1, num3 - num1);
+                            ScriptStatement scriptStatement = new ScriptStatement();
+                            scriptStatement.text = str3.Trim();
+                            scriptStatement.line = FindLineNumber(num1, lineNumbers);
+                            scriptStatement.position = num1 - lineNumbers[scriptStatement.line];
+                            list.Add(scriptStatement);
+                            num1 = num3 + str1.Length;
+                        }
+                    }
+                }
+            }
+            if (num1 < query.Length - 1)
+            {
+                string str2 = query.Substring(num1).Trim();
+                if (!string.IsNullOrEmpty(str2))
+                {
+                    ScriptStatement scriptStatement = new ScriptStatement();
+                    scriptStatement.text = str2;
+                    scriptStatement.line = FindLineNumber(num1, lineNumbers);
+                    scriptStatement.position = num1 - lineNumbers[scriptStatement.line];
+                    list.Add(scriptStatement);
+                }
+            }
+            return list;
+        }
+
+        private int FindLineNumber(int position, List<int> lineNumbers)
+        {
+            int index = 0;
+            while (index < lineNumbers.Count && position < lineNumbers[index])
+                ++index;
+            return index;
+        }
+
+        private void AdjustDelimiterEnd(string query, MySqlTokenizer tokenizer)
+        {
+            int stopIndex = tokenizer.StopIndex;
+            char c = query[stopIndex];
+            while (!char.IsWhiteSpace(c) && stopIndex < query.Length - 1)
+                c = query[++stopIndex];
+            tokenizer.StopIndex = stopIndex;
+            tokenizer.Position = stopIndex;
         }
     }
 }

--- a/product/roundhouse.databases.mysql/MySqlTokenizer.cs
+++ b/product/roundhouse.databases.mysql/MySqlTokenizer.cs
@@ -1,0 +1,337 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace roundhouse.databases.mysql
+{
+    class MySqlTokenizer
+    {
+        private string sql;
+        private int startIndex;
+        private int stopIndex;
+        private bool ansiQuotes;
+        private bool backslashEscapes;
+        private bool returnComments;
+        private bool multiLine;
+        private bool sqlServerMode;
+        private bool quoted;
+        private bool isComment;
+        private int pos;
+
+        public string Text
+        {
+            get
+            {
+                return this.sql;
+            }
+            set
+            {
+                this.sql = value;
+                this.pos = 0;
+            }
+        }
+
+        public bool AnsiQuotes
+        {
+            get
+            {
+                return this.ansiQuotes;
+            }
+            set
+            {
+                this.ansiQuotes = value;
+            }
+        }
+
+        public bool BackslashEscapes
+        {
+            get
+            {
+                return this.backslashEscapes;
+            }
+            set
+            {
+                this.backslashEscapes = value;
+            }
+        }
+
+        public bool MultiLine
+        {
+            get
+            {
+                return this.multiLine;
+            }
+            set
+            {
+                this.multiLine = value;
+            }
+        }
+
+        public bool SqlServerMode
+        {
+            get
+            {
+                return this.sqlServerMode;
+            }
+            set
+            {
+                this.sqlServerMode = value;
+            }
+        }
+
+        public bool Quoted
+        {
+            get
+            {
+                return this.quoted;
+            }
+            private set
+            {
+                this.quoted = value;
+            }
+        }
+
+        public bool IsComment
+        {
+            get
+            {
+                return this.isComment;
+            }
+        }
+
+        public int StartIndex
+        {
+            get
+            {
+                return this.startIndex;
+            }
+            set
+            {
+                this.startIndex = value;
+            }
+        }
+
+        public int StopIndex
+        {
+            get
+            {
+                return this.stopIndex;
+            }
+            set
+            {
+                this.stopIndex = value;
+            }
+        }
+
+        public int Position
+        {
+            get
+            {
+                return this.pos;
+            }
+            set
+            {
+                this.pos = value;
+            }
+        }
+
+        public bool ReturnComments
+        {
+            get
+            {
+                return this.returnComments;
+            }
+            set
+            {
+                this.returnComments = value;
+            }
+        }
+
+        public MySqlTokenizer()
+        {
+            this.backslashEscapes = true;
+            this.multiLine = true;
+            this.pos = 0;
+        }
+
+        public MySqlTokenizer(string input)
+            : this()
+        {
+            this.sql = input;
+        }
+
+        public List<string> GetAllTokens()
+        {
+            List<string> list = new List<string>();
+            for (string str = this.NextToken(); str != null; str = this.NextToken())
+                list.Add(str);
+            return list;
+        }
+
+        public string NextToken()
+        {
+            if (this.FindToken())
+                return this.sql.Substring(this.startIndex, this.stopIndex - this.startIndex);
+            else
+                return (string)null;
+        }
+
+        public static bool IsParameter(string s)
+        {
+            return !string.IsNullOrEmpty(s) && ((int)s[0] == 63 || s.Length > 1 && (int)s[0] == 64 && (int)s[1] != 64);
+        }
+
+        public string NextParameter()
+        {
+            while (this.FindToken())
+            {
+                if (this.stopIndex - this.startIndex >= 2)
+                {
+                    char ch1 = this.sql[this.startIndex];
+                    char ch2 = this.sql[this.startIndex + 1];
+                    if ((int)ch1 == 63 || (int)ch1 == 64 && (int)ch2 != 64)
+                        return this.sql.Substring(this.startIndex, this.stopIndex - this.startIndex);
+                }
+            }
+            return (string)null;
+        }
+
+        public bool FindToken()
+        {
+            this.isComment = this.quoted = false;
+            this.startIndex = this.stopIndex = -1;
+            while (this.pos < this.sql.Length)
+            {
+                char ch = this.sql[this.pos++];
+                if (!char.IsWhiteSpace(ch))
+                {
+                    if ((int)ch == 96 || (int)ch == 39 || (int)ch == 34 || (int)ch == 91 && this.SqlServerMode)
+                        this.ReadQuotedToken(ch);
+                    else if ((int)ch == 35 || (int)ch == 45 || (int)ch == 47)
+                    {
+                        if (!this.ReadComment(ch))
+                            this.ReadSpecialToken();
+                    }
+                    else
+                        this.ReadUnquotedToken();
+                    if (this.startIndex != -1)
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        public string ReadParenthesis()
+        {
+            StringBuilder stringBuilder = new StringBuilder("(");
+            int startIndex = this.StartIndex;
+            for (string str = this.NextToken(); str != null; str = this.NextToken())
+            {
+                stringBuilder.Append(str);
+                if (str == ")" && !this.Quoted)
+                    return ((object)stringBuilder).ToString();
+            }
+            throw new InvalidOperationException("Unable to parse SQL");
+        }
+
+        private bool ReadComment(char c)
+        {
+            if ((int)c == 47 && (this.pos >= this.sql.Length || (int)this.sql[this.pos] != 42) || (int)c == 45 && (this.pos + 1 >= this.sql.Length || (int)this.sql[this.pos] != 45 || (int)this.sql[this.pos + 1] != 32))
+                return false;
+            string str = "\n";
+            if ((int)this.sql[this.pos] == 42)
+                str = "*/";
+            int num1 = this.pos - 1;
+            int num2 = this.sql.IndexOf(str, this.pos);
+            if (str == "\n")
+                num2 = this.sql.IndexOf('\n', this.pos);
+            int num3 = num2 != -1 ? num2 + str.Length : this.sql.Length - 1;
+            this.pos = num3;
+            if (this.ReturnComments)
+            {
+                this.startIndex = num1;
+                this.stopIndex = num3;
+                this.isComment = true;
+            }
+            return true;
+        }
+
+        private void CalculatePosition(int start, int stop)
+        {
+            this.startIndex = start;
+            this.stopIndex = stop;
+            int num = this.MultiLine ? 1 : 0;
+        }
+
+        private void ReadUnquotedToken()
+        {
+            this.startIndex = this.pos - 1;
+            if (!this.IsSpecialCharacter(this.sql[this.startIndex]))
+            {
+                for (; this.pos < this.sql.Length; ++this.pos)
+                {
+                    char c = this.sql[this.pos];
+                    if (char.IsWhiteSpace(c) || this.IsSpecialCharacter(c))
+                        break;
+                }
+            }
+            this.Quoted = false;
+            this.stopIndex = this.pos;
+        }
+
+        private void ReadSpecialToken()
+        {
+            this.startIndex = this.pos - 1;
+            this.stopIndex = this.pos;
+            this.Quoted = false;
+        }
+
+        private void ReadQuotedToken(char quoteChar)
+        {
+            if ((int)quoteChar == 91)
+                quoteChar = ']';
+            this.startIndex = this.pos - 1;
+            bool flag1 = false;
+            bool flag2 = false;
+            for (; this.pos < this.sql.Length; ++this.pos)
+            {
+                char ch = this.sql[this.pos];
+                if ((int)ch == (int)quoteChar && !flag1)
+                {
+                    flag2 = true;
+                    break;
+                }
+                else if (flag1)
+                    flag1 = false;
+                else if ((int)ch == 92 && this.BackslashEscapes)
+                    flag1 = true;
+            }
+            if (flag2)
+                ++this.pos;
+            this.Quoted = flag2;
+            this.stopIndex = this.pos;
+        }
+
+        private bool IsQuoteChar(char c)
+        {
+            if ((int)c != 96 && (int)c != 39)
+                return (int)c == 34;
+            else
+                return true;
+        }
+
+        private bool IsParameterMarker(char c)
+        {
+            if ((int)c != 64)
+                return (int)c == 63;
+            else
+                return true;
+        }
+
+        private bool IsSpecialCharacter(char c)
+        {
+            return !char.IsLetterOrDigit(c) && (int)c != 36 && ((int)c != 95 && (int)c != 46) && !this.IsParameterMarker(c);
+        }
+    }
+}

--- a/product/roundhouse.databases.mysql/roundhouse.databases.mysql.csproj
+++ b/product/roundhouse.databases.mysql/roundhouse.databases.mysql.csproj
@@ -100,6 +100,7 @@
     </Compile>
     <Compile Include="MySqlAdoNetProviderResolver.cs" />
     <Compile Include="MySqlDatabase.cs" />
+    <Compile Include="MySqlTokenizer.cs" />
     <Compile Include="orm\ScriptsRunErrorMapping.cs" />
     <Compile Include="orm\ScriptsRunMapping.cs" />
     <Compile Include="orm\VersionMapping.cs" />


### PR DESCRIPTION
Issues Fixed: 
1) In order to allow SPROC files with variables to work, updated initialize_connections and build_connection_string to set 'Allow User Variables' = True
2) Fixed the CommandTimeout commandline option not being respected by MySqlDatabase. Fix involved updating 'run_sql' to use the method 'setup_database_command' instead of doing 
`var connection = connection_type == ConnectionType.Admin
                ? admin_connection.underlying_type().downcast_to<MySqlConnection>()
                : server_connection.underlying_type().downcast_to<MySqlConnection>();`

In order to use 'setup_datatbase_command' I needed to not use the MySqlScript class which only accepts a MySqlConnection object instead of an an IDbCommand (which is where the CommandTimeout is set)
