### PR TITLE
Fix log4net dependency

### DIFF
--- a/nuget/roundhouse.lib/roundhouse.lib.nuspec
+++ b/nuget/roundhouse.lib/roundhouse.lib.nuspec
@@ -14,7 +14,7 @@
     <tags>roundhouse db migration database migrator chucknorris</tags>
     <iconUrl>https://raw.github.com/chucknorris/roundhouse/master/nuget/RoundhousE_Logo.NuGet.jpg</iconUrl>
     <dependencies>
-      <dependency id="log4net" version="[1.2.10]" />
+      <dependency id="log4net" version="2.0.0" />
       <dependency id="FluentNHibernate" version="1.3.0.717" />
     </dependencies>
   </metadata>

--- a/nuget/roundhouse.msbuild/roundhouse.msbuild.nuspec
+++ b/nuget/roundhouse.msbuild/roundhouse.msbuild.nuspec
@@ -14,7 +14,7 @@
     <tags>roundhouse db migration database migrator chucknorris msbuild</tags>
     <iconUrl>https://raw.github.com/chucknorris/roundhouse/master/nuget/RoundhousE_Logo.NuGet.jpg</iconUrl>
     <dependencies>
-      <dependency id="log4net" version="[1.2.10]" />
+      <dependency id="log4net" version="2.0.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
The NuGet packages depend on an older version of log4net than the version that is actually used throughout the code. This causes installation problems in most NuGet clients.

The lastest version is 1.2.15, roundhouse depends on 1.2.11, but the NuGet packages are configured to require exactly 1.2.10 instead of 1.2.11 or newer.

This PR fixes the version restriction, and makes it less strict because it causes problems in projects that use a newer version of log4net.
