### PR TITLE
Add init for tls 1.x support

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using log4net;
 using roundhouse.consoles;
 using roundhouse.databases;
@@ -26,6 +27,8 @@ namespace roundhouse.console
         private static void Main(string[] args)
         {
             Log4NetAppender.configure();
+
+            init_security_protocol();
 
             int exit_code = 0;
 
@@ -427,6 +430,12 @@ namespace roundhouse.console
                 Console.WriteLine("{0}Please press enter to continue...", Environment.NewLine);
                 Console.Read();
             }
+        }
+
+        public static void init_security_protocol()
+        {
+            // allow tls
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12 | SecurityProtocolType.Ssl3;
         }
 
         private static RoundhouseMigrationRunner get_migration_runner(ConfigurationPropertyHolder configuration)


### PR DESCRIPTION
TLS 1.2 connections are failing when a connection is initialised to a database sever running TLS 1.2 only - this init method adds support for these connections.
