### PR TITLE
Added SqlDataFileDirectory and SqlLogFileDirectory tokens

### DIFF
--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -61,6 +61,10 @@
 
         public string SqlFilesDirectory { get; set; }
 
+        public string SqlDataFileDirectory { get; set; }
+
+        public string SqlLogFileDirectory { get; set; }
+
         public string RepositoryPath { get; set; }
 
         public string Version { get; set; }

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -15,6 +15,8 @@ namespace roundhouse.consoles
         public int CommandTimeout { get; set; }
         public int CommandTimeoutAdmin { get; set; }
         public string SqlFilesDirectory { get; set; }
+        public string SqlDataFileDirectory { get; set; }
+        public string SqlLogFileDirectory { get; set; }
         public string RepositoryPath { get; set; }
         public string Version { get; set; }
         public string VersionFile { get; set; }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -15,6 +15,8 @@ namespace roundhouse.infrastructure.app
         int CommandTimeout { get; set; }
         int CommandTimeoutAdmin { get; set; }
         string SqlFilesDirectory { get; set; }
+        string SqlDataFileDirectory { get; set; }
+        string SqlLogFileDirectory { get; set; }
         string RepositoryPath { get; set; }
         string Version { get; set; }
         string VersionFile { get; set; }


### PR DESCRIPTION
Added SqlDataFileDirectory and SqlLogFileDirectory for use with token replacement of custom create database scripts as physical location of data (.mdf) and log (.ldf) files usually differ on servers.  I saw there was another pull request for a more extensible custom defined tokens, but it stalled.

https://github.com/chucknorris/roundhouse/pull/231

Thanks