### PR TITLE
Change NuGet.exe reference in build config

### DIFF
--- a/Settings/UppercuT.config
+++ b/Settings/UppercuT.config
@@ -102,7 +102,7 @@
   <property name="app.nitriq" value="Nitriq.Console.exe" overwrite="false" />
   <property name="app.xbuild" value="${path::get-full-path(folder.program_files)}${path.separator}Mono-2.8${path.separator}bin${path.separator}xbuild.bat" overwrite="false" />
   <property name="app.eazfuscator" value="..${path.separator}${folder.references}${path.separator}Eazfuscator.NET${path.separator}Eazfuscator.NET.exe" overwrite="false" />
-  <property name="app.nuget" value="..${path.separator}${folder.references}${path.separator}NuGet${path.separator}NuGet.exe" overwrite="false" />
+  <property name="app.nuget" value="..${path.separator}.NuGet${path.separator}NuGet.exe" overwrite="false" />
   <property name="app.strongname" value="${path::get-full-path(folder.program_files)}${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}sn.exe" overwrite="false" />
 
   <property name="app.ruby" value="C:${path.separator}Ruby${path.separator}bin${path.separator}ruby.exe" overwrite="false" />


### PR DESCRIPTION
The Nuget.exe in lib was removed in a prior commit (while the one in .nuget was updated). Without the lib version we
can't actually build packages for publishing. Rather than restore the redundant copy of the exe, I updated the build config
to reference the one that we do have.