### PR TITLE
Speed up test for MD5 implementation equivalence

### DIFF
--- a/product/roundhouse.tests/cryptography/CryptographicServiceSpecs.cs
+++ b/product/roundhouse.tests/cryptography/CryptographicServiceSpecs.cs
@@ -55,7 +55,7 @@ namespace roundhouse.tests.cryptography
         [TestFixture]
         public class when_using_an_unofficial_md5_implementation
         {
-            const int passes = 1000000;
+            const int passes = 2000;
             const int max_len = 10240;
 
             private int seed = Environment.TickCount;


### PR DESCRIPTION
Test was performing 1M iterations over a 10K byte field. This was taking
60-90s depending on the machine. I dropped this to 2K iterations.