### PR TITLE
Add appveyor.yml to git repo

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+build_script:
+- ps: .\build.ps1
+test:
+  assemblies:
+    only:
+    - '**\*tests.dll'
+artifacts:
+- path: .\code_drop\packages\*.nupkg
+  name: Nuget packages
+- path: .\code_drop\log\*
+  name: Logs


### PR DESCRIPTION
We should keep the appveyor.yml in the git repo. I don't have access to the one used in the chuchnorris project, but I created my own, and exported that appveyor.yml, to run only the unit tests (not integration tests), and add the .nupkgs to the build artifacts.