### PR TITLE
Removed some warnings in the build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,8 @@ $onAppVeyor = $("$($env:APPVEYOR)" -eq "True");
 pushd $root
 
 
-"`n * Generating version number"
+"`n"
+" * Generating version number"
 $gitVersion = (GitVersion | ConvertFrom-Json)
 
 If ($onAppVeyor) {
@@ -24,7 +25,7 @@ If ($onAppVeyor) {
     appveyor UpdateBuild -Version "$newVersion"
 }
 
-"`n * Restoring nuget packages"
+" * Restoring nuget packages"
 nuget restore -NonInteractive -Verbosity quiet
 
 # Create output and log dirs if they don't exist (don't know why this is necessary - works on my box...)
@@ -36,15 +37,8 @@ If (!(Test-Path $LOGDIR)) {
 }
 
 
-"`n * Building and packaging"
-msbuild /t:"Build;Pack" /p:DropFolder=$CODEDROP /p:Version="$($gitVersion.FullSemVer)" /p:NoPackageAnalysis=true /nologo /v:m /fl /flp:"LogFile=$LOGDIR\msbuild.log;Verbosity=n" /p:Configuration=Build /p:Platform="Any CPU"
-
-# Workaround until test filter is updated - remove then.
-If ($onAppVeyor) {
-    dir -r product/roundhouse.tests.integration -i roundhouse.tests.integration.dll | % { 
-        rm -fo $_;
-    }
-}
+" * Building and packaging"
+msbuild /t:"Build;Pack" /p:DropFolder=$CODEDROP /p:Version="$($gitVersion.FullSemVer)" /p:NoPackageAnalysis=true /nologo /v:q /fl /flp:"LogFile=$LOGDIR\msbuild.log;Verbosity=n" /p:Configuration=Build /p:Platform="Any CPU"
 
 # AppVeyor runs the test automagically, no need to run explicitly with nunit-console.exe. 
 # But we want to run the tests on localhost too.

--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -615,7 +615,6 @@ namespace roundhouse.console
                 configuration.Drop,
                 configuration.DoNotCreateDatabase,
                 configuration.WithTransaction,
-                configuration.RecoveryModeSimple,
                 configuration);
         }
 

--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -111,6 +111,7 @@ namespace roundhouse.databases.sqlserver
             {
                 run_sql(create_roundhouse_schema_script(),ConnectionType.Default);
             }
+#pragma warning disable 168
             catch (Exception ex)
             {
                 throw;
@@ -118,6 +119,7 @@ namespace roundhouse.databases.sqlserver
                 //    "Either the schema has already been created OR {0} with provider {1} does not provide a facility for creating roundhouse schema at this time.{2}{3}",
                 //    GetType(), provider, Environment.NewLine, ex.Message);
             }
+#pragma warning restore 168
         }
 
         public string create_roundhouse_schema_script()

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -229,7 +229,6 @@ namespace roundhouse.tasks
                 Drop,
                 DoNotCreateDatabase,
                 WithTransaction,
-                RecoveryModeSimple,
                 this);
 
             roundhouse_runner.run();

--- a/product/roundhouse.tests.integration/infrastructure/persistence/NHibernateSessionFactorySpecs.cs
+++ b/product/roundhouse.tests.integration/infrastructure/persistence/NHibernateSessionFactorySpecs.cs
@@ -39,7 +39,6 @@ namespace roundhouse.tests.integration.infrastructure.persistence
             private static void get_schema_export(Configuration cfg)
             {
                 build_schema(cfg);
-                int i = 0;
             }
 
             [Observation]

--- a/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/tokens/TokenReplacerSpecs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace roundhouse.tests.infrastructure.app.tokens
@@ -52,13 +53,13 @@ namespace roundhouse.tests.infrastructure.app.tokens
                 TokenReplacer.replace_tokens(configuration, "ALTER DATABASE DatabaseName").should_be_equal_to("ALTER DATABASE DatabaseName");
             }
 
-            [Observation]
+            [Observation, CLSCompliant(false)]
             public void if_given_bracket_bracket_databasename_bracket_bracket_should_replace_with_the_DatabaseName_from_the_configuration()
             {
                 TokenReplacer.replace_tokens(configuration, "ALTER DATABASE {{databasename}}").should_be_equal_to("ALTER DATABASE " + database_name);
             }
 
-            [Observation]
+            [Observation, CLSCompliant(false)]
             public void if_given_bracket_bracket_DATABASENAME_bracket_bracket_should_replace_with_the_DatabaseName_from_the_configuration()
             {
                 TokenReplacer.replace_tokens(configuration, "ALTER DATABASE {{DATABASENAME}}").should_be_equal_to("ALTER DATABASE " + database_name);

--- a/product/roundhouse.tests/runners/RoundhouseMigratorRunnerSpecs.cs
+++ b/product/roundhouse.tests/runners/RoundhouseMigratorRunnerSpecs.cs
@@ -28,7 +28,7 @@ namespace roundhouse.tests.runners
             {
                 configuration = new DefaultConfiguration
                 {
-                    EnvironmentName = "TEST",
+                    EnvironmentNames = "TEST",
                     Drop = false ,
                     Silent = true
                 };
@@ -56,7 +56,6 @@ namespace roundhouse.tests.runners
                             configuration.Drop,
                             configuration.DoNotCreateDatabase,
                             configuration.WithTransaction,
-                            configuration.RecoveryModeSimple,
                             configuration);
 
                 var container_mock = new Mock<InversionContainer>();

--- a/product/roundhouse/Migrate.cs
+++ b/product/roundhouse/Migrate.cs
@@ -116,7 +116,6 @@ namespace roundhouse
                 this.configuration.Drop,
                 this.configuration.DoNotCreateDatabase,
                 this.configuration.WithTransaction,
-                this.configuration.RecoveryModeSimple,
                 this.configuration);
         }
 

--- a/product/roundhouse/runners/RoundhouseMigrationRunner.cs
+++ b/product/roundhouse/runners/RoundhouseMigrationRunner.cs
@@ -25,7 +25,6 @@ namespace roundhouse.runners
         public bool dropping_the_database { get; set; }
         private readonly bool dont_create_the_database;
         private bool run_in_a_transaction;
-        private readonly bool use_simple_recovery;
         private readonly ConfigurationPropertyHolder configuration;
         private const string SQL_EXTENSION = "*.sql";
 
@@ -40,7 +39,6 @@ namespace roundhouse.runners
             bool dropping_the_database,
             bool dont_create_the_database,
             bool run_in_a_transaction,
-            bool use_simple_recovery,
             ConfigurationPropertyHolder configuration)
         {
             this.known_folders = known_folders;
@@ -53,7 +51,6 @@ namespace roundhouse.runners
             this.dropping_the_database = dropping_the_database;
             this.dont_create_the_database = dont_create_the_database;
             this.run_in_a_transaction = run_in_a_transaction;
-            this.use_simple_recovery = use_simple_recovery;
             this.configuration = configuration;
         }
 


### PR DESCRIPTION
Didn't know what to do with the last ones, as they're obsolete APIs actually exposes via command-line parameters. Should we remove them from the command line options too? They've probably been deprecated for 4 years, but has the deprecation been communicated to end-users of `rh.exe`, or can we expect someone to rely on those? And if, should we care? Or just announce a breaking change?