### PR TITLE
Revert too eager deletion of the EnvironmentName config setting

### DIFF
--- a/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
+++ b/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
@@ -124,7 +124,10 @@ namespace roundhouse.infrastructure.app
             }
             if (string.IsNullOrEmpty(configuration_property_holder.EnvironmentNames))
             {
-                configuration_property_holder.EnvironmentNames = ApplicationParameters.default_environment_name;
+                if (!string.IsNullOrEmpty(configuration_property_holder.EnvironmentName))
+                    configuration_property_holder.EnvironmentNames = configuration_property_holder.EnvironmentName;
+                else
+                    configuration_property_holder.EnvironmentNames = ApplicationParameters.default_environment_name;
             }
             if (string.IsNullOrEmpty(configuration_property_holder.OutputPath))
             {

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -40,6 +40,8 @@ namespace roundhouse.infrastructure.app
         string VersionTableName { get; set; }
         string ScriptsRunTableName { get; set; }
         string ScriptsRunErrorsTableName { get; set; }
+        [Obsolete("Use EnvironmentNames")]
+        string EnvironmentName { get; set; }
         string EnvironmentNames { get; set; }
         bool Restore { get; set; }
         string RestoreFromPath { get; set; }


### PR DESCRIPTION
This reverts a bit too eager deletion of the `EnvironmentName` configuration property, from pull request #295. 