### PR TITLE
Erikbra fix too eager delete

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -28,7 +28,7 @@ namespace roundhouse.console
 
     public class Program
     {
-        private static readonly char[] OptionsSplit = new[] { ',' };
+        private static readonly char[] OptionsSplit = new[] { ',',';' };
 
         private static readonly ILog the_logger = LogManager.GetLogger(typeof(Program));
 
@@ -259,7 +259,7 @@ namespace roundhouse.console
                 //environment(s)
                 .Add("env=|environment=|environmentname=|envs=|environments=|environmentnames=",
                      string.Format(
-                         "EnvironmentName(s) - This allows RH to be environment aware and only run scripts that are in a particular environment based on the naming of the script. LOCAL.something.ENV.sql would only be run in the LOCAL environment. Multiple environments may be specified as a comma-separated list. Defaults to \"{0}\".",
+                         "EnvironmentName(s) - This allows RH to be environment aware and only run scripts that are in a particular environment based on the naming of the script. LOCAL.something.ENV.sql would only be run in the LOCAL environment. Multiple environments may be specified as a comma or semicolon separated list. Defaults to \"{0}\".",
                          ApplicationParameters.default_environment_name),
                      environmentOption =>
                      {

--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -28,6 +28,8 @@ namespace roundhouse.console
 
     public class Program
     {
+        private static readonly char[] OptionsSplit = new[] { ',' };
+
         private static readonly ILog the_logger = LogManager.GetLogger(typeof(Program));
 
         private static void Main(string[] args)
@@ -259,7 +261,13 @@ namespace roundhouse.console
                      string.Format(
                          "EnvironmentName(s) - This allows RH to be environment aware and only run scripts that are in a particular environment based on the naming of the script. LOCAL.something.ENV.sql would only be run in the LOCAL environment. Multiple environments may be specified as a comma-separated list. Defaults to \"{0}\".",
                          ApplicationParameters.default_environment_name),
-                     option => configuration.EnvironmentNames = option)
+                     environmentOption =>
+                     {
+                         foreach (var environment in environmentOption.Split(OptionsSplit, StringSplitOptions.RemoveEmptyEntries))
+                         {
+                             configuration.EnvironmentNames.Add(environment);
+                         }
+                     })
                 //restore
                 .Add("restore",
                      "Restore - This instructs RH to do a restore (with the restorefrompath parameter) of a database before running migration scripts. Defaults to false.",

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -16,6 +16,7 @@ namespace roundhouse.tasks
     using resolvers;
     using runners;
     using Logger = roundhouse.infrastructure.logging.Logger;
+    using System.Linq;
 
     public sealed class Roundhouse : ITask, ConfigurationPropertyHolder
     {
@@ -26,6 +27,7 @@ namespace roundhouse.tasks
         public Roundhouse()
         {
             this.loggingHelper = new TaskLoggingHelper(this);
+            EnvironmentNames = new List<string>();
         }
 
         #region MSBuild
@@ -110,9 +112,15 @@ namespace roundhouse.tasks
         public string ScriptsRunErrorsTableName { get; set; }
 
         [Obsolete("Use EnvironmentNames")]
-        public string EnvironmentName { get; set; }
-
-        public string EnvironmentNames { get; set; }
+        public string EnvironmentName {
+            get { return EnvironmentNames.SingleOrDefault(); }
+            set
+            {
+                EnvironmentNames.Clear();
+                EnvironmentNames.Add(value);
+            }
+        }
+        public IList<string> EnvironmentNames { get; private set; }
 
         public bool Restore { get; set; }
 

--- a/product/roundhouse.tests/migrators/DefaultDatabaseMigratorSpecs.cs
+++ b/product/roundhouse.tests/migrators/DefaultDatabaseMigratorSpecs.cs
@@ -17,7 +17,8 @@ namespace roundhouse.tests.migrators
 
             protected concern_for_database_migrator()
             {
-                default_configuration = new DefaultConfiguration {EnvironmentNames = "TEST"};
+                default_configuration = new DefaultConfiguration();
+                default_configuration.EnvironmentNames.Add("TEST");
                 default_database_migrator = new DefaultDatabaseMigrator(new MockDatabase(null), null, default_configuration);
             }
 
@@ -108,7 +109,9 @@ namespace roundhouse.tests.migrators
             private readonly DefaultConfiguration default_configuration;
             protected concern_for_database_migrator_with_multiple_environments()
             {
-                default_configuration = new DefaultConfiguration {EnvironmentNames = "TEST,SPECIAL"};
+                default_configuration = new DefaultConfiguration();
+                default_configuration.EnvironmentNames.Add("TEST");
+                default_configuration.EnvironmentNames.Add("SPECIAL");
                 default_database_migrator = new DefaultDatabaseMigrator(new MockDatabase(null), null, default_configuration);
             }
 

--- a/product/roundhouse.tests/runners/RoundhouseMigratorRunnerSpecs.cs
+++ b/product/roundhouse.tests/runners/RoundhouseMigratorRunnerSpecs.cs
@@ -28,10 +28,10 @@ namespace roundhouse.tests.runners
             {
                 configuration = new DefaultConfiguration
                 {
-                    EnvironmentNames = "TEST",
                     Drop = false ,
                     Silent = true
                 };
+                configuration.EnvironmentNames.Add("TEST");
 
                 var database_mock = new Mock<Database>();
                 var filesystem_mock = new Mock<FileSystemAccess>();

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -6,9 +6,14 @@ namespace roundhouse.consoles
     using databases;
     using infrastructure.app;
     using infrastructure.logging;
+    using System.Linq;
 
     public sealed class DefaultConfiguration : ConfigurationPropertyHolder
     {
+        public DefaultConfiguration()
+        {
+            EnvironmentNames = new List<string>();
+        }
         public Logger Logger { get; set; }
         public string ServerName { get; set; }
         public string DatabaseName { get; set; }
@@ -41,8 +46,15 @@ namespace roundhouse.consoles
         public string ScriptsRunTableName { get; set; }
         public string ScriptsRunErrorsTableName { get; set; }
         [Obsolete("Use EnvironmentNames")]
-        public string EnvironmentName { get; set; }
-        public string EnvironmentNames { get; set; }
+        public string EnvironmentName {
+            get { return EnvironmentNames.SingleOrDefault(); }
+            set
+            {
+                EnvironmentNames.Clear();
+                EnvironmentNames.Add(value);
+            }
+        }
+        public IList<string> EnvironmentNames { get; private set; }
         public bool Restore { get; set; }
         public string RestoreFromPath { get; set; }
         public string RestoreCustomOptions { get; set; }

--- a/product/roundhouse/environments/DefaultEnvironmentSet.cs
+++ b/product/roundhouse/environments/DefaultEnvironmentSet.cs
@@ -11,8 +11,6 @@
         public DefaultEnvironmentSet(ConfigurationPropertyHolder configuration_property_holder)
         {
             set_items = configuration_property_holder.EnvironmentNames
-                .Split(',')
-                .Where(x => !string.IsNullOrWhiteSpace(x))
                 .Select(x => new DefaultEnvironment(x.Trim()))
                 .ToList();
         }

--- a/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
+++ b/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
@@ -124,7 +124,10 @@ namespace roundhouse.infrastructure.app
             }
             if (string.IsNullOrEmpty(configuration_property_holder.EnvironmentNames))
             {
-                configuration_property_holder.EnvironmentNames = ApplicationParameters.default_environment_name;
+                if (!string.IsNullOrEmpty(configuration_property_holder.EnvironmentName))
+                    configuration_property_holder.EnvironmentNames = configuration_property_holder.EnvironmentName;
+                else
+                    configuration_property_holder.EnvironmentNames = ApplicationParameters.default_environment_name;
             }
             if (string.IsNullOrEmpty(configuration_property_holder.OutputPath))
             {

--- a/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
+++ b/product/roundhouse/infrastructure.app/ApplicationConfiguraton.cs
@@ -25,6 +25,7 @@ namespace roundhouse.infrastructure.app
     using resolvers;
     using StructureMap;
     using Container = roundhouse.infrastructure.containers.Container;
+    using System.Linq;
 
     public static class ApplicationConfiguraton
     {
@@ -122,12 +123,9 @@ namespace roundhouse.infrastructure.app
             {
                 configuration_property_holder.VersionXPath = ApplicationParameters.default_version_x_path;
             }
-            if (string.IsNullOrEmpty(configuration_property_holder.EnvironmentNames))
+            if (!configuration_property_holder.EnvironmentNames.Any())
             {
-                if (!string.IsNullOrEmpty(configuration_property_holder.EnvironmentName))
-                    configuration_property_holder.EnvironmentNames = configuration_property_holder.EnvironmentName;
-                else
-                    configuration_property_holder.EnvironmentNames = ApplicationParameters.default_environment_name;
+                configuration_property_holder.EnvironmentNames.Add(ApplicationParameters.default_environment_name);
             }
             if (string.IsNullOrEmpty(configuration_property_holder.OutputPath))
             {

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -42,7 +42,7 @@ namespace roundhouse.infrastructure.app
         string ScriptsRunErrorsTableName { get; set; }
         [Obsolete("Use EnvironmentNames")]
         string EnvironmentName { get; set; }
-        string EnvironmentNames { get; set; }
+        IList<string> EnvironmentNames { get; }
         bool Restore { get; set; }
         string RestoreFromPath { get; set; }
         string RestoreCustomOptions { get; set; }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -40,6 +40,8 @@ namespace roundhouse.infrastructure.app
         string VersionTableName { get; set; }
         string ScriptsRunTableName { get; set; }
         string ScriptsRunErrorsTableName { get; set; }
+        [Obsolete("Use EnvironmentNames")]
+        string EnvironmentName { get; set; }
         string EnvironmentNames { get; set; }
         bool Restore { get; set; }
         string RestoreFromPath { get; set; }


### PR DESCRIPTION
Includes and supersedes #296 

EnvironmentName is restored (and marked obsolete), but is now implemented in terms of EnvironmentNames and the splitting is done immediately.