### PR TITLE
{WIP} Changed OracleConnection to use Managed provider

### DIFF
--- a/product/roundhouse.databases.oracle/OracleDatabase.cs
+++ b/product/roundhouse.databases.oracle/OracleDatabase.cs
@@ -1,4 +1,6 @@
-using System.Data.OracleClient;
+using System.Data.Common;
+using Oracle.ManagedDataAccess.Client;
+
 using roundhouse.infrastructure.logging;
 
 namespace roundhouse.databases.oracle
@@ -84,7 +86,12 @@ namespace roundhouse.databases.oracle
 
         public override void set_provider()
         {
-            provider = "System.Data.OracleClient";
+            provider = "Oracle.ManagedDataAccess.Client";
+        }
+
+        protected override DbProviderFactory get_db_provider_factory()
+        {
+            return OracleClientFactory.Instance;
         }
 
         protected override void connection_specific_setup(IDbConnection connection)

--- a/product/roundhouse.databases.oracle/RoundhousEOracleDriver.cs
+++ b/product/roundhouse.databases.oracle/RoundhousEOracleDriver.cs
@@ -1,7 +1,6 @@
-﻿using System.Data.OracleClient;
+﻿using Oracle.ManagedDataAccess.Client;
 using NHibernate.Driver;
 using NHibernate.SqlTypes;
-using roundhouse.infrastructure.logging;
 
 namespace roundhouse.databases.oracle
 {
@@ -22,7 +21,7 @@ namespace roundhouse.databases.oracle
             //Mapping file will need to be update to use StringClob as the property type
             if ((sqlType is StringClobSqlType))
             {
-                ((OracleParameter)dbParam).OracleType = OracleType.NClob;
+                ((OracleParameter)dbParam).OracleDbType = OracleDbType.NClob;
             }
         }
     }

--- a/product/roundhouse.databases.oracle/roundhouse.databases.oracle.csproj
+++ b/product/roundhouse.databases.oracle/roundhouse.databases.oracle.csproj
@@ -40,13 +40,13 @@
    <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
     <PackageReference Include="Iesi.Collections" Version="3.3.2.4000" />
     <PackageReference Include="NHibernate" Version="3.3.2.4000" />
+    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\roundhouse\roundhouse.csproj" />

--- a/product/roundhouse.tests.integration/app.config
+++ b/product/roundhouse.tests.integration/app.config
@@ -8,4 +8,13 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+  <!--
+  <oracle.manageddataaccess.client>
+    <version number="*">
+      <dataSources>
+        <dataSource alias="TestRoundhousE" descriptor="Data Source=MyOracleDB;Integrated Security=yes;" />
+      </dataSources>
+   </version>
+  </oracle.manageddataaccess.client>
+  -->
+  </configuration>

--- a/product/roundhouse.tests.integration/databases/OracleDatabaseSpecs.cs
+++ b/product/roundhouse.tests.integration/databases/OracleDatabaseSpecs.cs
@@ -1,0 +1,56 @@
+using System;
+using roundhouse.databases.oracle;
+
+namespace roundhouse.tests.integration.databases
+{
+    using roundhouse.databases.mysql;
+    using roundhouse.infrastructure.logging.custom;
+
+    public class OracleDatabaseSpecs
+    {
+        public abstract class concern_for_OracleDatabase :  TinySpec, IDisposable
+        {
+            protected static string database_name = "TestRoundhousE";
+            protected static string sql_files_folder = @"..\..\..\..\db\Oracle\TestRoundhousE";
+            
+            public void Dispose()
+            {
+                new Migrate().Set(p =>
+                {
+                    p.ConnectionString = "Data Source=//localhost/XE;User Id=SYSTEM;Password=123456";
+                    p.SqlFilesDirectory = sql_files_folder;
+                    p.DatabaseType = "oracle";
+                    p.Drop = true;
+                    p.DoNotCreateDatabase = true;
+                    p.Silent = true;
+                }).Run();
+            }
+        }
+
+        [Concern(typeof(OracleDatabase))]
+        public class when_running_the_migrator_with_oracle : concern_for_OracleDatabase
+        {
+            protected static object result;
+
+            public override void Context() { }
+            public override void Because() 
+            {
+                new Migrate().Set(p =>
+                {
+                    p.Logger = new ConsoleLogger();
+                    p.ConnectionString = "Data Source=//localhost/XE;User Id=SYSTEM;Password=123456";
+                    p.SqlFilesDirectory = sql_files_folder;
+                    p.DatabaseType = "oracle";
+                    p.DoNotCreateDatabase = true;
+                    p.Silent = true;
+                }).Run();
+            }
+
+            [Observation]
+            public void should_successfully_run()
+            {
+                //nothing needed here
+            }
+        }
+    }
+}

--- a/product/roundhouse.tests.integration/databases/SqlServerDatabaseSpecs.cs
+++ b/product/roundhouse.tests.integration/databases/SqlServerDatabaseSpecs.cs
@@ -101,7 +101,7 @@ namespace roundhouse.tests.integration.databases
             public void should_have_the_correct_default_restore_options()
             {
                 //NOTE: this is not conclusive since this could vary from system to system depending on where you store stuff. This test needs some work to make it go to the database.
-                result.ShouldEqual(@", MOVE 'TestRoundhousE' TO 'C:\Program Files (x86)\Microsoft SQL Server\MSSQL10.MSSQLSERVER\MSSQL\DATA\TestRoundhousE.mdf', MOVE 'TestRoundhousE_log' TO 'C:\Program Files (x86)\Microsoft SQL Server\MSSQL10.MSSQLSERVER\MSSQL\DATA\TestRoundhousE_log.LDF'");
+                result.ShouldEqual(@", MOVE 'TestRoundhousE' TO 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\DATA\TestRoundhousE.mdf', MOVE 'TestRoundhousE_log' TO 'C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\DATA\TestRoundhousE_log.ldf'");
             }
 
         }

--- a/product/roundhouse.tests.integration/roundhouse.tests.integration.csproj
+++ b/product/roundhouse.tests.integration/roundhouse.tests.integration.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <ProjectReference Include="..\roundhouse.console\roundhouse.console.csproj" />
     <ProjectReference Include="..\roundhouse.databases.mysql\roundhouse.databases.mysql.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.oracle\roundhouse.databases.oracle.csproj" />
     <ProjectReference Include="..\roundhouse.databases.sqlserver\roundhouse.databases.sqlserver.csproj" />
     <ProjectReference Include="..\roundhouse\roundhouse.csproj" />
   </ItemGroup>

--- a/product/roundhouse/databases/AdoNetDatabase.cs
+++ b/product/roundhouse/databases/AdoNetDatabase.cs
@@ -24,12 +24,17 @@
 
         protected virtual AdoNetConnection GetAdoNetConnection(string conn_string)
         {
-            provider_factory = DbProviderFactories.GetFactory(provider);
+            provider_factory = get_db_provider_factory();
             IDbConnection connection = provider_factory.CreateConnection();
             connection_specific_setup(connection);
             
             connection.ConnectionString = conn_string;
             return new AdoNetConnection(connection);
+        }
+
+        protected virtual DbProviderFactory get_db_provider_factory()
+        {
+            return DbProviderFactories.GetFactory(provider);
         }
 
         protected virtual void connection_specific_setup(IDbConnection connection)

--- a/product/roundhouse/infrastructure/ApplicationParameters.cs
+++ b/product/roundhouse/infrastructure/ApplicationParameters.cs
@@ -46,12 +46,12 @@ namespace roundhouse.infrastructure
         public static readonly int default_restore_timeout = 900;
         public static readonly bool default_disable_output = false;
 
-        public static string get_merged_assembly_name()
+        public static string get_merged_assembly_name(string type_defined_in_assembly = "roundhouse")
         {
             string merged_assembly_name = "rh";
             Log.bound_to(typeof(ApplicationParameters)).log_a_debug_event_containing("The executing assembly is \"{0}\"", Assembly.GetExecutingAssembly().Location);
 
-            if (Assembly.GetExecutingAssembly().Location.to_lower().Contains("roundhouse.dll")) merged_assembly_name = "roundhouse";
+            if (Assembly.GetExecutingAssembly().Location.to_lower().Contains("roundhouse.dll")) merged_assembly_name = type_defined_in_assembly;
 
             return merged_assembly_name;
         }

--- a/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
+++ b/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
@@ -75,8 +75,8 @@ namespace roundhouse.infrastructure.persistence
             try
             {
                 string key = configuration_holder.DatabaseType.Substring(0, configuration_holder.DatabaseType.IndexOf(',')) + ", " +
-                             ApplicationParameters.get_merged_assembly_name();
-                return build_session_factory(func_dictionary[key](), Assembly.GetExecutingAssembly(),top_namespace, additional_function);
+                             ApplicationParameters.get_merged_assembly_name(top_namespace);
+                return build_session_factory(func_dictionary[key](), Type.GetType(key).Assembly, top_namespace, additional_function);
                 //return build_session_factory(func_dictionary[key](), DefaultAssemblyLoader.load_assembly(ApplicationParameters.get_merged_assembly_name()),
                                              //top_namespace, additional_function);
             }


### PR DESCRIPTION
I was tired of the warnings about System.Data.OracleClient being outdated, so I tried to convert to using https://www.nuget.org/packages/Oracle.ManagedDataAccess/ to connect to Oracle databases. In the passage, I created an integration test for Oracle too (made a copy of the MySql one), but I'm having a really, really hard time getting it to work.

Mainly I get a ORA-01017, which is basically "wrong password". However, it is not..
Other people are having the problem too: 
https://stackoverflow.com/questions/14476875/ora-01017-invalid-username-password-when-connecting-to-11g-database-from-9i-clie
https://dba.stackexchange.com/questions/145055/ora-01017-invalid-username-password-logon-denied-from-sql-developer-but-sqlplu

A couple of questions: 
1) Are there any Oracle heads out there who could help me test? I haven't done Oracle in 10 years, and that was from Java
1) Are anyone able to get the new integration test i wrote running with the *current* oracle driver? (it has client dependencies, I didn't want to go down that rabbit hole)