### PR TITLE
Add GitVersion-config

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,8 @@
+assembly-versioning-scheme: None
+mode: ContinuousDelivery
+branches:
+  master:
+    mode: ContinuousDelivery
+    tag: pre
+ignore:
+  sha: []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,21 @@
-version: 1.0.{build}
 image: Visual Studio 2017
+
+install:
+  - choco install gitversion.portable -pre -y
+
+before_build:
+  - ps: gitversion /l console /output buildserver
+
 build_script:
-- ps: .\build.ps1
+  - ps: .\build.ps1
+
 test:
   assemblies:
     only:
-    - '**\*tests.dll'
+      - '**\*tests.dll'
+
 artifacts:
-- path: .\code_drop\packages\*.nupkg
-  name: Nuget packages
-- path: .\code_drop\log\*
-  name: Logs
+  - path: .\code_drop\packages\*.nupkg
+    name: Nuget packages
+  - path: .\code_drop\log\*
+    name: Logs

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env powershell
+#!/usr/bin/env pwsh
 
 $MSBUILD=msbuild
 
@@ -19,7 +19,7 @@ pushd $root
 $gitVersion = (GitVersion | ConvertFrom-Json)
 
 If ($onAppVeyor) {
-    $newVersion="$($gitVersion.FullSemVer).$env:APPVEYOR_BUILD_NUMBER"
+    $newVersion="$($gitVersion.FullSemVer)"
     Write-host "   - Updating appveyor build version to: $newVersion"
     $env:APPVEYOR_BUILD_VERSION="$newVersion"
     appveyor UpdateBuild -Version "$newVersion"


### PR DESCRIPTION
Added GitVersion-config that is supposed to work when we work in a GitHubFlow style (i.e. no separate develop-branch, just PRs off master). Versions from tags, and uses semantic versioning for commits after a release. Uses `pre` as suffix for builds not from a tag.

`master` as of now should be `0.8.9-pre.X`

when we are ready for release, we just tag master with `0.8.9`, and the version number becomes `0.8.9` (no suffix).


