### PR TITLE
{WIP} Add push to MyGet from AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,23 @@ before_build:
 
 build_script:
   - ps: .\build.ps1
-
+  
 test:
   assemblies:
     only:
       - '**\*tests.dll'
-
+      
 artifacts:
   - path: .\code_drop\packages\*.nupkg
     name: Nuget packages
   - path: .\code_drop\log\*
     name: Logs
+
+deploy:
+  provider: NuGet
+  server:  https://www.myget.org/F/roundhouse/api/v2/package
+  api_key:
+    secure: XWER/H0IkJ8JWFm+n3/lr7hHoNFAX/VpRD+AfpZo2EUgQkQKhrMxHa4aYZPogsvY
+  skip_symbols: true 
+  artifact: /.*\.nupkg/
+  disable_publish_on_pr: true


### PR DESCRIPTION
Add a step to push to MyGet from the AppVeyor builds. Uses encryptet MyGet ApiKey (needs to be inserted, of course), using [https://ci.appveyor.com/tools/encrypt](https://ci.appveyor.com/tools/encrypt). It encrypts with a unique key per AppVeyor account. 

It would be really nice if AppVeyor supported merging of AppVeyor.yml and GUI, because then we could put the URI to the MyGet feed (which varies for e.g. erikbra and roundhouse) and the Api Key in the GUI instead of the checked-in file. But it does the job.

This only pushes "proper" builds (not builds of PRs). So we would push (of course with a -pre tag if #300 is merged too) whenever master is built on its own, but not on PR builds.  