### PR TITLE
Fix for IndexOutOfRangeException when token value is empty

### DIFF
--- a/product/roundhouse/infrastructure.app/UserTokenParser.cs
+++ b/product/roundhouse/infrastructure.app/UserTokenParser.cs
@@ -23,8 +23,8 @@
 
             if (pairs.Any(p => !p.Contains("="))) throw new FormatException("Wrong format");
 
-            return pairs.ToDictionary(p => p.Split(new string[] { "=" }, StringSplitOptions.RemoveEmptyEntries)[0],
-                p => p.Split(new string[] { "=" }, StringSplitOptions.RemoveEmptyEntries)[1]);
+            return pairs.ToDictionary(p => p.Split(new string[] { "=" }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(),
+                p => p.Split(new string[] { "=" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault());
         }
     }
 }


### PR DESCRIPTION
If the token value is empty, roundhouse crashes:
Index was outside the bounds of the array. System.IndexOutOfRangeException: Index was outside the bounds of the array.    at roundhouse.infrastructure.app.tokens.UserTokenParser.<Parse>b__2(String p)    at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)    at roundhouse.infrastructure.app.tokens.UserTokenParser.Parse(String option)    at (...)
Using FirstOrDefault and LastOrDefault instead of accessing array elements directly fixes this.