### PR TITLE
Fixed Issue #306 - added roundhouse.lib.merged

### DIFF
--- a/product/roundhouse.console/roundhouse.console.csproj
+++ b/product/roundhouse.console/roundhouse.console.csproj
@@ -96,11 +96,11 @@
     <PropertyGroup>
       <IgnoreFile>..\..\build.custom\ilmerge.internalize.ignore.txt</IgnoreFile>
       <ILMerge>..\..\lib\ILMerge\ILMerge.exe</ILMerge>
-      <ILMergeLog>$(ILMergeDir)ILMerge.log</ILMergeLog>
+      <ILMergeLog>$(ILMergeDir)roundhouse.console.ILMerge.log</ILMergeLog>
       <ILMergeSource>$(OutputPath)$(AssemblyName).exe</ILMergeSource>
       <ILMergeCommand>$(ILMerge) /internalize:$(IgnoreFile) /target:exe /out:$(ILMergeTarget) /log:$(ILMergeLog) /ndebug /zeroPeKind /allowDup $(ILMergeSource)  @(ILMergeAssemblies, ' ')</ILMergeCommand>
     </PropertyGroup>
-    <RemoveDir Directories="$(ILMergeDir)" Condition="Exists($(ILMergeDir))" />
+    <Delete Files="$(ILMergeLog);$(ILMergeTarget)" Condition="Exists($(ILMergeDir))" />
     <MakeDir Directories="$(ILMergeDir)" />
     <Message Importance="high" Text="ILMerge-ing into $(ILMergeTarget)" />
     <Exec Command="$(ILMergeCommand)" />

--- a/product/roundhouse.console/roundhouse.nuspec
+++ b/product/roundhouse.console/roundhouse.nuspec
@@ -4,8 +4,8 @@
     <id>roundhouse</id>
     <title>RoundhousE</title>
     <version>$version$</version>
-    <authors>Rob Reynolds</authors>
-    <owners>Rob Reynolds</owners>
+    <authors>Rob Reynolds, Andy Davis, Erik A. Brandstadmoen</authors>
+    <owners>Rob Reynolds, Andy Davis, Erik A. Brandstadmoen</owners>
     <summary>RoundhousE - Professional Database Change and Versioning Management</summary>
     <description>RoundhousE is a Professional Database Change and Versioning Management tool. Type rh /? for options</description>
     <projectUrl>http://projectroundhouse.org</projectUrl>

--- a/product/roundhouse.databases.access/roundhouse.databases.access.csproj
+++ b/product/roundhouse.databases.access/roundhouse.databases.access.csproj
@@ -43,10 +43,8 @@
     <ProjectReference Include="..\roundhouse\roundhouse.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentNHibernate" version="1.3.0.733" />
-    <PackageReference Include="Iesi.Collections" version="3.3.2.4000" />
-    <PackageReference Include="NHibernate" version="3.3.2.4000" />
-    <PackageReference Include="NHibernate.JetDriver" version="2.0.0.1001"/>
+    <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
+    <PackageReference Include="NHibernate.JetDriver" Version="2.0.0.1001"/>
   </ItemGroup>
  <ItemGroup>
     <None Include="app.config" />

--- a/product/roundhouse.databases.mysql/roundhouse.databases.mysql.csproj
+++ b/product/roundhouse.databases.mysql/roundhouse.databases.mysql.csproj
@@ -41,10 +41,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentNHibernate" version="1.3.0.733" />
-    <PackageReference Include="Iesi.Collections" version="3.3.2.4000" />
-    <PackageReference Include="NHibernate" version="3.3.2.4000" />
-    <PackageReference Include="Mysql.Data" version="6.9.9" />
+    <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
+    <PackageReference Include="Mysql.Data" Version="6.10.5" />
   </ItemGroup>
  <ItemGroup>
     <ProjectReference Include="..\roundhouse\roundhouse.csproj" />

--- a/product/roundhouse.databases.postgresql/roundhouse.databases.postgresql.csproj
+++ b/product/roundhouse.databases.postgresql/roundhouse.databases.postgresql.csproj
@@ -42,8 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
-    <PackageReference Include="Iesi.Collections" Version="3.3.2.4000" />
-    <PackageReference Include="NHibernate" Version="3.3.2.4000" />
     <PackageReference Include="Npgsql" Version="3.1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/product/roundhouse.databases.sqlite/roundhouse.databases.sqlite.csproj
+++ b/product/roundhouse.databases.sqlite/roundhouse.databases.sqlite.csproj
@@ -47,14 +47,8 @@
         <Reference Include="System.Xml"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="EntityFramework" Version="6.1.3" />
         <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
-        <PackageReference Include="Iesi.Collections" Version="3.3.2.4000" />
-        <PackageReference Include="NHibernate" Version="3.3.2.4000" />
         <PackageReference Include="System.Data.SQLite" Version="1.0.105.2" />
-        <PackageReference Include="System.Data.SQLite.Core" Version="1.0.105.2" />
-        <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.105.2" />
-        <PackageReference Include="System.Data.SQLite.Linq" Version="1.0.105.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\roundhouse\roundhouse.csproj" />

--- a/product/roundhouse.databases.sqlserver/roundhouse.databases.sqlserver.csproj
+++ b/product/roundhouse.databases.sqlserver/roundhouse.databases.sqlserver.csproj
@@ -39,8 +39,9 @@
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304.0" />
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data" Version="6.0.1304.1" />
     <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
-    <PackageReference Include="Iesi.Collections" Version="3.3.2.4000" />
+    <PackageReference Include="FluentNHibernate" Version="1.3.0.733" />
     <PackageReference Include="NHibernate" Version="3.3.2.4000" />
+    <PackageReference Include="Iesi.Collections" Version="3.3.2.4000" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/product/roundhouse.lib.merged/roundhouse.lib.merged.csproj
+++ b/product/roundhouse.lib.merged/roundhouse.lib.merged.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFramework>net461</TargetFramework>
     <CLSCompliant>true</CLSCompliant>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -69,18 +69,15 @@
       <Link>roundhouse.ico</Link>
     </None>
   </ItemGroup>
+  
   <!-- Merge properties and target -->
   <PropertyGroup>
     <ILMergeDir>..\..\code_drop\merge\</ILMergeDir>
     <ILMergeTarget>$(ILMergeDir)roundhouse.dll</ILMergeTarget>
   </PropertyGroup>
+  
   <Target Name="ILMerge" AfterTargets="Build">
     <ItemGroup>
-      <!--
-      <ILMergeAssemblies Include="$(OutputPath)*.dll" />
-      <ILMergeAssemblies Exclude="$(OutputPath)$(AssemblyName).dll" />
-      <ILMergeAssemblies Exclude="$(OutputPath)FluentNHibernate.dll" />
-      -->
       <ILMergeAssemblies Include="$(OutputPath)roundhouse*.dll" />
       <ILMergeAssemblies Remove="$(OutputPath)$(AssemblyName).dll" />
     </ItemGroup>
@@ -90,16 +87,19 @@
       <ILMergeLog>$(ILMergeDir)roundhouse.ILMerge.log</ILMergeLog>
       <ILMergeCommand>$(ILMerge) /internalize:$(IgnoreFile) /target:dll /out:$(ILMergeTarget) /log:$(ILMergeLog) /ndebug /zeroPeKind /allowDup  @(ILMergeAssemblies, ' ')</ILMergeCommand>
     </PropertyGroup>
-    <Delete Files="$(ILMergeLog);$(ILMergeTarget)" Condition="Exists($(ILMergeDir))" />
+    <Delete Files="$(ILMergeLog)" Condition="Exists('$(ILMergeLog)')" />
+    <Delete Files="$(ILMergeTarget)" Condition="Exists('$(ILMergeTarget)')" />
     <MakeDir Directories="$(ILMergeDir)" />
     <Message Importance="high" Text="ILMerge-ing into $(ILMergeTarget)" />
     <Exec Command="$(ILMergeCommand)" />
   </Target>
+  
   <!-- Nuspec properties (for generating NuGet package) -->
   <PropertyGroup>
     <NuspecFile>roundhouse.lib.nuspec</NuspecFile>
     <NuspecProperties>mergedDll=$(ILMergeTarget);version=$(NugetVersion)</NuspecProperties>
   </PropertyGroup>
+  
   <!-- Copy to drop folder after packaging -->
   <Target Name="CopyToDropFolder" AfterTargets="Pack" Condition="'$(DropFolder)' != ''">
     <ItemGroup>

--- a/product/roundhouse.lib.merged/roundhouse.lib.merged.csproj
+++ b/product/roundhouse.lib.merged/roundhouse.lib.merged.csproj
@@ -1,0 +1,110 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <CLSCompliant>true</CLSCompliant>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>roundhouse</RootNamespace>
+    <AssemblyName>roundhouse.lib.merged</AssemblyName>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NoWarn>NU1701</NoWarn>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <VersionPrefix>0.8.9</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
+    <Version Condition="'$(Version)' == ''">$(VersionPrefix)</Version>
+    <Version Condition="'$(Version)' == '$(VersionPrefix)' And '$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
+    <NugetVersion Condition="'$(NugetVersion)' == ''">$(Version)</NugetVersion>
+    <PackageVersion>$(NugetVersion)</PackageVersion>
+    <PackageId>roundhouse.lib</PackageId>
+    <Title>RoundhousE Library</Title>
+    <Authors>Rob Reynolds</Authors>
+    <Description>RoundhousE is a Professional Database Change and Versioning Management tool.</Description>
+    <PackageProjectUrl>http://projectroundhouse.org</PackageProjectUrl>
+    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageTags>roundhouse db migration database migrator chucknorris</PackageTags>
+    <PackageIconUrl>https://raw.github.com/chucknorris/roundhouse/master/nuget/RoundhousE_Logo.NuGet.jpg</PackageIconUrl>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\roundhouse.databases.access\roundhouse.databases.access.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.mysql\roundhouse.databases.mysql.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.oracle\roundhouse.databases.oracle.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.postgresql\roundhouse.databases.postgresql.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.sqlite\roundhouse.databases.sqlite.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.sqlserver2000\roundhouse.databases.sqlserver2000.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.sqlserverce\roundhouse.databases.sqlserverce.csproj" />
+    <ProjectReference Include="..\roundhouse.databases.sqlserver\roundhouse.databases.sqlserver.csproj" />
+    <ProjectReference Include="..\roundhouse\roundhouse.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\docs\logo\roundhouse.ico">
+      <Link>roundhouse.ico</Link>
+    </None>
+  </ItemGroup>
+  <!-- Merge properties and target -->
+  <PropertyGroup>
+    <ILMergeDir>..\..\code_drop\merge\</ILMergeDir>
+    <ILMergeTarget>$(ILMergeDir)roundhouse.dll</ILMergeTarget>
+  </PropertyGroup>
+  <Target Name="ILMerge" AfterTargets="Build">
+    <ItemGroup>
+      <!--
+      <ILMergeAssemblies Include="$(OutputPath)*.dll" />
+      <ILMergeAssemblies Exclude="$(OutputPath)$(AssemblyName).dll" />
+      <ILMergeAssemblies Exclude="$(OutputPath)FluentNHibernate.dll" />
+      -->
+      <ILMergeAssemblies Include="$(OutputPath)roundhouse*.dll" />
+      <ILMergeAssemblies Remove="$(OutputPath)$(AssemblyName).dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <IgnoreFile>..\..\build.custom\ilmerge.internalize.ignore.txt</IgnoreFile>
+      <ILMerge>..\..\lib\ILMerge\ILMerge.exe</ILMerge>
+      <ILMergeLog>$(ILMergeDir)roundhouse.ILMerge.log</ILMergeLog>
+      <ILMergeCommand>$(ILMerge) /internalize:$(IgnoreFile) /target:dll /out:$(ILMergeTarget) /log:$(ILMergeLog) /ndebug /zeroPeKind /allowDup  @(ILMergeAssemblies, ' ')</ILMergeCommand>
+    </PropertyGroup>
+    <Delete Files="$(ILMergeLog);$(ILMergeTarget)" Condition="Exists($(ILMergeDir))" />
+    <MakeDir Directories="$(ILMergeDir)" />
+    <Message Importance="high" Text="ILMerge-ing into $(ILMergeTarget)" />
+    <Exec Command="$(ILMergeCommand)" />
+  </Target>
+  <!-- Nuspec properties (for generating NuGet package) -->
+  <PropertyGroup>
+    <NuspecFile>roundhouse.lib.nuspec</NuspecFile>
+    <NuspecProperties>mergedDll=$(ILMergeTarget);version=$(NugetVersion)</NuspecProperties>
+  </PropertyGroup>
+  <!-- Copy to drop folder after packaging -->
+  <Target Name="CopyToDropFolder" AfterTargets="Pack" Condition="'$(DropFolder)' != ''">
+    <ItemGroup>
+      <NugetPackages Include="$(OutputPath)..\**\*.nupkg" />
+    </ItemGroup>
+    <Copy SourceFiles="@(NugetPackages)" DestinationFolder="$(DropFolder)\packages" />
+  </Target>
+</Project>

--- a/product/roundhouse.lib.merged/roundhouse.lib.nuspec
+++ b/product/roundhouse.lib.merged/roundhouse.lib.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata>
+    <id>roundhouse.lib</id>
+    <title>RoundhousE Library</title>
+    <version>$version$</version>
+    <authors>Rob Reynolds, Andy Davis, Erik A. Brandstadmoen</authors>
+    <owners>Rob Reynolds</owners>
+    <summary>RoundhousE - Professional Database Change and Versioning Management</summary>
+    <description>RoundhousE is a Professional Database Change and Versioning Management tool. Type rh /? for options</description>
+    <projectUrl>http://projectroundhouse.org</projectUrl>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>roundhouse db migration database migrator chucknorris</tags>
+    <dependencies>
+      <dependency id="FluentNHibernate" version="1.3.0" />
+      <dependency id="Iesi.Collections" version="3.3.2.4000" />
+      <dependency id="NHibernate" version="3.3.2.4000" />
+      <dependency id="NHibernate.JetDriver" version="2.0.0" />
+      <dependency id="Npgsql" version="3.1.1.0" />
+      <dependency id="System.Data.SQLite" version="1.0.105.2" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
+      <dependency id="Microsoft.SqlServer.Compact" version="4.0.8876.1" />
+    </dependencies>
+	<iconUrl>https://raw.github.com/chucknorris/roundhouse/master/nuget/RoundhousE_Logo.NuGet.jpg</iconUrl>
+  </metadata>
+  <files>
+    <file src="$mergedDll$" target="lib\net461" />
+  </files>
+</package>

--- a/product/roundhouse/roundhouse.csproj
+++ b/product/roundhouse/roundhouse.csproj
@@ -22,17 +22,6 @@
     <Version Condition="'$(Version)' == '$(VersionPrefix)' And '$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <NugetVersion Condition="'$(NugetVersion)' == ''">$(Version)</NugetVersion>
 
-    <PackageVersion>$(NugetVersion)</PackageVersion>
-    <PackageId>roundhouse.lib</PackageId>
-    <Title>RoundhousE Library</Title>
-    <Authors>Rob Reynolds</Authors>
-    <Description>RoundhousE is a Professional Database Change and Versioning Management tool.</Description>
-    <PackageProjectUrl>http://projectroundhouse.org</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageTags>roundhouse db migration database migrator chucknorris</PackageTags>
-	  <PackageIconUrl>https://raw.github.com/chucknorris/roundhouse/master/nuget/RoundhousE_Logo.NuGet.jpg</PackageIconUrl>
-
 
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/roundhouse.sln
+++ b/roundhouse.sln
@@ -45,6 +45,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "roundhouse.databases.postgr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "roundhouse.databases.sqlserverce", "product\roundhouse.databases.sqlserverce\roundhouse.databases.sqlserverce.csproj", "{3447F080-CF50-4B02-9521-671E7AEE8D34}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "roundhouse.lib.merged", "product\roundhouse.lib.merged\roundhouse.lib.merged.csproj", "{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Build|Any CPU = Build|Any CPU
@@ -130,6 +132,12 @@ Global
 		{3447F080-CF50-4B02-9521-671E7AEE8D34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3447F080-CF50-4B02-9521-671E7AEE8D34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3447F080-CF50-4B02-9521-671E7AEE8D34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}.Build|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}.Build|Any CPU.Build.0 = Debug|Any CPU
+		{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BB8E05F-CEC6-4CC8-87CF-8A9C439C8122}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Added another project, just for the merge of all the DLLs into one for
Nuget packaging. Made more of the original Nuget dependencies proper
dependencies of roundhouse.lib instead of merging some of them. I think
merging them might lead to problems if someone uses both roundhouse.lib
and one of the original dependency nuget packages.