### PR TITLE
Added methods in the Oracle DB section to use the PLSQL methods

### DIFF
--- a/product/roundhouse.databases.oracle/OracleDatabase.cs
+++ b/product/roundhouse.databases.oracle/OracleDatabase.cs
@@ -102,6 +102,21 @@ namespace roundhouse.databases.oracle
             run_sql(create_sequence_script(scripts_run_errors_table_name), ConnectionType.Default);
         }
 
+        public override void create_or_update_roundhouse_tables()
+        {
+
+            Log.bound_to(this).log_an_info_event_containing("Creating table [{0}].[{1}].", roundhouse_schema_name, version_table_name);
+            run_sql(PLSQLSpecific.create_roundhouse_version_table(roundhouse_schema_name, version_table_name), ConnectionType.Default);
+
+            Log.bound_to(this).log_an_info_event_containing("Creating table [{0}].[{1}].", roundhouse_schema_name, scripts_run_table_name);
+            run_sql(PLSQLSpecific.create_roundhouse_scripts_run_table(roundhouse_schema_name, version_table_name, scripts_run_table_name),
+                    ConnectionType.Default);
+
+            Log.bound_to(this).log_an_info_event_containing("Creating table [{0}].[{1}].", roundhouse_schema_name, scripts_run_errors_table_name);
+            run_sql(PLSQLSpecific.create_roundhouse_scripts_run_errors_table(roundhouse_schema_name, scripts_run_errors_table_name),
+                    ConnectionType.Default);
+        }
+
         public string create_sequence_script(string table_name)
         {
             return string.Format(

--- a/product/roundhouse.databases.oracle/PLSQLSpecific.cs
+++ b/product/roundhouse.databases.oracle/PLSQLSpecific.cs
@@ -3,7 +3,7 @@ namespace roundhouse.databases.oracle
     public sealed class PLSQLSpecific
     {
 
-        public string create_roundhouse_version_table(string roundhouse_schema_name, string version_table_name)
+        public static string create_roundhouse_version_table(string roundhouse_schema_name, string version_table_name)
         {
             return string.Format(
                 @"
@@ -24,22 +24,13 @@ namespace roundhouse.databases.oracle
                             
                             EXECUTE IMMEDIATE 'ALTER TABLE {0}_{1} ADD (
                                 PRIMARY KEY(id)
-                            )';
-
-                            EXECUTE IMMEDIATE 'CREATE SEQUENCE {0}_{1}id
-                            START WITH 1
-                            INCREMENT BY 1
-                            MINVALUE 1
-                            MAXVALUE 999999999999999999999999999
-                            CACHE 20
-                            NOCYCLE 
-                            NOORDER';
+                            )';                           
                         END IF;
                     END;
                 ", roundhouse_schema_name, version_table_name);
         }
 
-        public string create_roundhouse_scripts_run_table(string roundhouse_schema_name, string version_table_name, string scripts_run_table_name)
+        public static string create_roundhouse_scripts_run_table(string roundhouse_schema_name, string version_table_name, string scripts_run_table_name)
         {
             return string.Format(
                 @"
@@ -63,16 +54,7 @@ namespace roundhouse.databases.oracle
 
                             EXECUTE IMMEDIATE 'ALTER TABLE {0}_{1} ADD (
                                 PRIMARY KEY(id)
-                            )';
-
-                            EXECUTE IMMEDIATE 'CREATE SEQUENCE {0}_{1}id
-                            START WITH 1
-                            INCREMENT BY 1
-                            MINVALUE 1
-                            MAXVALUE 999999999999999999999999999
-                            CACHE 20
-                            NOCYCLE 
-                            NOORDER';
+                            )';                          
 
                             EXECUTE IMMEDIATE 'ALTER TABLE {0}_{1} ADD (
                                 CONSTRAINT FK_{1}_{2}_vid
@@ -85,7 +67,7 @@ namespace roundhouse.databases.oracle
                 roundhouse_schema_name, scripts_run_table_name, version_table_name);
         }
 
-        public string create_roundhouse_scripts_run_errors_table(string roundhouse_schema_name, string scripts_run_errors_table_name)
+        public static string create_roundhouse_scripts_run_errors_table(string roundhouse_schema_name, string scripts_run_errors_table_name)
         {
             return string.Format(
                 @"
@@ -110,16 +92,7 @@ namespace roundhouse.databases.oracle
 
                             EXECUTE IMMEDIATE 'ALTER TABLE {0}_{1} ADD (
                                 PRIMARY KEY(id)
-                            )';
-
-                            EXECUTE IMMEDIATE 'CREATE SEQUENCE {0}_{1}id
-                            START WITH 1
-                            INCREMENT BY 1
-                            MINVALUE 1
-                            MAXVALUE 999999999999999999999999999
-                            CACHE 20
-                            NOCYCLE 
-                            NOORDER';
+                            )';        
                             
                         END IF;
                     END;
@@ -129,7 +102,7 @@ namespace roundhouse.databases.oracle
 
         //functions
 
-        public string get_version(string roundhouse_schema_name, string version_table_name, string repository_path)
+        public static string get_version(string roundhouse_schema_name, string version_table_name, string repository_path)
         {
             return string.Format(
                  @"
@@ -143,7 +116,7 @@ namespace roundhouse.databases.oracle
                 roundhouse_schema_name, version_table_name, repository_path);
         }
 
-        public string get_version_parameterized(string roundhouse_schema_name, string version_table_name)
+        public static string get_version_parameterized(string roundhouse_schema_name, string version_table_name)
         {
             return string.Format(
                  @"
@@ -157,7 +130,7 @@ namespace roundhouse.databases.oracle
                 roundhouse_schema_name, version_table_name);
         }
 
-        public string get_current_script_hash_parameterized(string roundhouse_schema_name, string scripts_run_table_name)
+        public static string get_current_script_hash_parameterized(string roundhouse_schema_name, string scripts_run_table_name)
         {
             return string.Format(
                 @"
@@ -172,7 +145,7 @@ namespace roundhouse.databases.oracle
                 );
         }
 
-        public string has_script_run_parameterized(string roundhouse_schema_name, string scripts_run_table_name)
+        public static string has_script_run_parameterized(string roundhouse_schema_name, string scripts_run_table_name)
         {
             return string.Format(
                 @"
@@ -185,7 +158,7 @@ namespace roundhouse.databases.oracle
                 );
         }
 
-        public string insert_script_run_parameterized(string roundhouse_schema_name, string scripts_run_table_name)
+        public static string insert_script_run_parameterized(string roundhouse_schema_name, string scripts_run_table_name)
         {
             return string.Format(
                 @"
@@ -213,7 +186,7 @@ namespace roundhouse.databases.oracle
                 roundhouse_schema_name, scripts_run_table_name);
         }
 
-        public string insert_script_run_error_parameterized(string roundhouse_schema_name, string scripts_run_errors_table_name)
+        public static string insert_script_run_error_parameterized(string roundhouse_schema_name, string scripts_run_errors_table_name)
         {
             return string.Format(
                 @"


### PR DESCRIPTION
We were having an issue using roundhouse over numerous schemas on the same oracle instance. 

If we had 2 schemas DB_DEV and DB_TEST, roundhouse would run fine on the DB_DEV instance, create the 3 roundhouse tables and populate them fine. When we came to run then on DB_TEST it would fail stating that the roundhouse tables did not exist. It appeared that it was checking for the existance of the roundhouse tables without taking into account it was under a different schema. 

After a bit of looking about we noticed the PLSQLSpecific class in the roundhouse.databases.oracle section, after re-instating that roundhouse works like a charm.

If this isnt a great idea and there is another way to address the issue we were noticing i'd be very interested to hear some thoughts.