### PR TITLE
Added rh.bat and .zip packaging

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ test:
       - '**\*tests.dll'
 
 after_build:
+  - 7z a .\code_drop\packages\RoundhousE.%GitVersion_SemVer%.zip .\code_drop\tmp\RoundhousE
   - 7z a .\code_drop\packages\RoundhousE.tar .\code_drop\tmp\RoundhousE
   - 7z a .\code_drop\packages\RoundhousE.%GitVersion_SemVer%.tar.gz .\code_drop\packages\RoundhousE.tar
   
@@ -24,6 +25,8 @@ artifacts:
     name: Nuget packages
   - path: .\code_drop\packages\*.tar.gz
     name: Dotnet core .tar.gz distro
+  - path: .\code_drop\packages\*.zip
+    name: Dotnet core .zip distro
   - path: .\code_drop\log\*
     name: Logs
 

--- a/product/roundhouse.console/rh.bat
+++ b/product/roundhouse.console/rh.bat
@@ -1,0 +1,5 @@
+@echo off
+SET DIR=%~dp0
+
+SET DLL=%DIR%\rh.dll 
+dotnet %DLL% %*

--- a/product/roundhouse.console/roundhouse.console.csproj
+++ b/product/roundhouse.console/roundhouse.console.csproj
@@ -80,6 +80,7 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <None Include="rh" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="rh.bat" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   
   <!-- Merge properties and target -->


### PR DESCRIPTION
It't easier to test the netcore version on Windows if distributed as a
.zip, and with at .bat file to execute.