### PR TITLE
Move token dictionary creation to ConfigurationPropertyHolder

### DIFF
--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -8,6 +8,7 @@ namespace roundhouse.tasks
     using infrastructure.app;
     using infrastructure.app.logging;
     using infrastructure.containers;
+    using infrastructure.extensions;
     using infrastructure.filesystem;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
@@ -206,6 +207,81 @@ namespace roundhouse.tasks
         public string ConfigurationFile { get; set; }
 
         #endregion
+
+        public IDictionary<string, string> to_token_dictionary()
+        {
+            var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { nameof(AfterMigrationFolderName), AfterMigrationFolderName.to_string() },
+                { nameof(AlterDatabaseFolderName), AlterDatabaseFolderName.to_string() },
+                { nameof(Baseline), Baseline.to_string() },
+                { nameof(BeforeMigrationFolderName), BeforeMigrationFolderName.to_string() },
+                { nameof(CommandTimeout), CommandTimeout.to_string() },
+                { nameof(CommandTimeoutAdmin), CommandTimeoutAdmin.to_string() },
+                { nameof(ConfigurationFile), ConfigurationFile.to_string() },
+                { nameof(ConnectionString), ConnectionString.to_string() },
+                { nameof(ConnectionStringAdmin), ConnectionStringAdmin.to_string() },
+                { nameof(CreateDatabaseCustomScript), CreateDatabaseCustomScript.to_string() },
+                { nameof(DatabaseName), DatabaseName.to_string() },
+                { nameof(DatabaseType), DatabaseType.to_string() },
+                { nameof(Debug), Debug.to_string() },
+                { nameof(DisableOutput), DisableOutput.to_string() },
+                { nameof(DisableTokenReplacement), DisableTokenReplacement.to_string() },
+                { nameof(DoNotAlterDatabase), DoNotAlterDatabase.to_string() },
+                { nameof(DoNotCreateDatabase), DoNotCreateDatabase.to_string() },
+                { nameof(DownFolderName), DownFolderName.to_string() },
+                { nameof(Drop), Drop.to_string() },
+                { nameof(DryRun), DryRun.to_string() },
+#pragma warning disable 618
+                { nameof(EnvironmentName), string.Join(",", EnvironmentNames) },
+#pragma warning restore 618
+                { nameof(EnvironmentNames), string.Join(",", EnvironmentNames) },
+                { nameof(FunctionsFolderName), FunctionsFolderName.to_string() },
+                { nameof(IndexesFolderName), IndexesFolderName.to_string() },
+                { nameof(Initialize), Initialize.to_string() },
+                { nameof(OutputPath), OutputPath.to_string() },
+                { nameof(PermissionsFolderName), PermissionsFolderName.to_string() },
+                { nameof(RecoveryMode), RecoveryMode.to_string() },
+                { nameof(RepositoryPath), RepositoryPath.to_string() },
+                { nameof(Restore), Restore.to_string() },
+                { nameof(RestoreCustomOptions), RestoreCustomOptions.to_string() },
+                { nameof(RestoreFromPath), RestoreFromPath.to_string() },
+                { nameof(RestoreTimeout), RestoreTimeout.to_string() },
+                { nameof(RunAfterCreateDatabaseFolderName), RunAfterCreateDatabaseFolderName.to_string() },
+                { nameof(RunAfterOtherAnyTimeScriptsFolderName), RunAfterOtherAnyTimeScriptsFolderName.to_string() },
+                { nameof(RunAllAnyTimeScripts), RunAllAnyTimeScripts.to_string() },
+                { nameof(RunBeforeUpFolderName), RunBeforeUpFolderName.to_string() },
+                { nameof(RunFirstAfterUpFolderName), RunFirstAfterUpFolderName.to_string() },
+                { nameof(SchemaName), SchemaName.to_string() },
+                { nameof(ScriptsRunErrorsTableName), ScriptsRunErrorsTableName.to_string() },
+                { nameof(ScriptsRunTableName), ScriptsRunTableName.to_string() },
+                { nameof(SearchAllSubdirectoriesInsteadOfTraverse), SearchAllSubdirectoriesInsteadOfTraverse.to_string() },
+                { nameof(ServerName), ServerName.to_string() },
+                { nameof(Silent), Silent.to_string() },
+                { nameof(SprocsFolderName), SprocsFolderName.to_string() },
+                { nameof(SqlFilesDirectory), SqlFilesDirectory.to_string() },
+                { nameof(TriggersFolderName), TriggersFolderName.to_string() },
+                { nameof(UpFolderName), UpFolderName.to_string() },
+                { nameof(Version), Version.to_string() },
+                { nameof(VersionFile), VersionFile.to_string() },
+                { nameof(VersionTableName), VersionTableName.to_string() },
+                { nameof(VersionXPath), VersionXPath.to_string() },
+                { nameof(ViewsFolderName), ViewsFolderName.to_string() },
+                { nameof(WarnAndIgnoreOnOneTimeScriptChanges), WarnAndIgnoreOnOneTimeScriptChanges.to_string() },
+                { nameof(WarnOnOneTimeScriptChanges), WarnOnOneTimeScriptChanges.to_string() },
+                { nameof(WithTransaction), WithTransaction.to_string() },
+            };
+
+            if (UserTokens != null)
+            {
+                foreach (var t in UserTokens)
+                {
+                    tokens[t.Key] = t.Value;
+                }
+            }
+
+            return tokens;
+        }
 
         public void run_the_task()
         {

--- a/product/roundhouse.tests/infrastructure.app/DefaultConfigurationSpecs.cs
+++ b/product/roundhouse.tests/infrastructure.app/DefaultConfigurationSpecs.cs
@@ -1,0 +1,129 @@
+﻿using System.Collections.Generic;
+
+namespace roundhouse.tests.infrastructure.app
+{
+    using consoles;
+    using roundhouse.infrastructure.app;
+    using Should;
+
+    public class DefaultConfigurationSpecs
+    {
+
+        public abstract class concern_for_DefaultConfiguration : TinySpec
+        {
+            protected ConfigurationPropertyHolder configuration;
+
+            public override void Context()
+            {
+                configuration = new DefaultConfiguration();
+            }
+        }
+
+        [Concern(typeof(DefaultConfiguration))]
+        public class when_single_environment_present : concern_for_DefaultConfiguration
+        {
+
+            public override void Because()
+            {
+                configuration.EnvironmentNames.Add("Environment1");
+            }
+
+            [Observation]
+            public void token_dictionary_should_have_single_environment_name()
+            {
+
+                var dict = configuration.to_token_dictionary();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                dict.TryGetValue(nameof(ConfigurationPropertyHolder.EnvironmentName), out var environment_name).ShouldBeTrue();
+                environment_name.ShouldEqual("Environment1");
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                dict.TryGetValue(nameof(ConfigurationPropertyHolder.EnvironmentNames), out var environment_names).ShouldBeTrue();
+                environment_names.ShouldEqual("Environment1");
+
+            }
+
+        }
+
+        [Concern(typeof(DefaultConfiguration))]
+        public class when_multiple_environments_present : concern_for_DefaultConfiguration
+        {
+
+            public override void Because()
+            {
+                configuration.EnvironmentNames.Add("Environment1");
+                configuration.EnvironmentNames.Add("Environment2");
+            }
+
+            [Observation]
+            public void token_dictionary_should_have_multiple_environment_names()
+            {
+
+                var dict = configuration.to_token_dictionary();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                dict.TryGetValue(nameof(ConfigurationPropertyHolder.EnvironmentName), out var environment_name).ShouldBeTrue();
+                environment_name.ShouldEqual("Environment1,Environment2");
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                dict.TryGetValue(nameof(ConfigurationPropertyHolder.EnvironmentNames), out var environment_names).ShouldBeTrue();
+                environment_names.ShouldEqual("Environment1,Environment2");
+
+            }
+
+        }
+
+        [Concern(typeof(DefaultConfiguration))]
+        public class when_custom_user_tokens_present : concern_for_DefaultConfiguration
+        {
+
+            public override void Because()
+            {
+                configuration.UserTokens = new Dictionary<string, string>
+                {
+                    {"UserId", "1"}
+                };
+            }
+
+            [Observation]
+            public void token_dictionary_should_have_multiple_environment_names()
+            {
+
+                var dict = configuration.to_token_dictionary();
+
+                dict.TryGetValue("UserId", out var user_id).ShouldBeTrue();
+                user_id.ShouldEqual("1");
+
+            }
+
+        }
+
+        [Concern(typeof(DefaultConfiguration))]
+        public class when_overriding_user_tokens_present : concern_for_DefaultConfiguration
+        {
+
+            public override void Because()
+            {
+                configuration.ServerName = "original";
+                configuration.UserTokens = new Dictionary<string, string>
+                {
+                    {"ServerName", "overridden"}
+                };
+            }
+
+            [Observation]
+            public void token_dictionary_should_have_multiple_environment_names()
+            {
+
+                var dict = configuration.to_token_dictionary();
+
+                dict.TryGetValue("ServerName", out var server_name).ShouldBeTrue();
+                server_name.ShouldEqual("overridden");
+
+            }
+
+        }
+
+    }
+}

--- a/product/roundhouse/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse/consoles/DefaultConfiguration.cs
@@ -5,6 +5,7 @@ namespace roundhouse.consoles
     using System;
     using databases;
     using infrastructure.app;
+    using infrastructure.extensions;
     using infrastructure.logging;
     using System.Linq;
 
@@ -83,5 +84,77 @@ namespace roundhouse.consoles
         public bool Initialize { get; set; }
         public string ConfigurationFile { get; set; }
         public System.Text.Encoding DefaultEncoding { get; set; }
-	}
+
+        public IDictionary<string, string> to_token_dictionary()
+        {
+            var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            tokens["AfterMigrationFolderName"] = AfterMigrationFolderName.to_string();
+            tokens["AlterDatabaseFolderName"] = AlterDatabaseFolderName.to_string();
+            tokens["Baseline"] = Baseline.to_string();
+            tokens["BeforeMigrationFolderName"] = BeforeMigrationFolderName.to_string();
+            tokens["CommandTimeout"] = CommandTimeout.to_string();
+            tokens["CommandTimeoutAdmin"] = CommandTimeoutAdmin.to_string();
+            tokens["ConfigurationFile"] = ConfigurationFile.to_string();
+            tokens["ConnectionString"] = ConnectionString.to_string();
+            tokens["ConnectionStringAdmin"] = ConnectionStringAdmin.to_string();
+            tokens["CreateDatabaseCustomScript"] = CreateDatabaseCustomScript.to_string();
+            tokens["DatabaseName"] = DatabaseName.to_string();
+            tokens["DatabaseType"] = DatabaseType.to_string();
+            tokens["Debug"] = Debug.to_string();
+            tokens["DisableOutput"] = DisableOutput.to_string();
+            tokens["DisableTokenReplacement"] = DisableTokenReplacement.to_string();
+            tokens["DoNotAlterDatabase"] = DoNotAlterDatabase.to_string();
+            tokens["DoNotCreateDatabase"] = DoNotCreateDatabase.to_string();
+            tokens["DownFolderName"] = DownFolderName.to_string();
+            tokens["Drop"] = Drop.to_string();
+            tokens["DryRun"] = DryRun.to_string();
+            tokens["EnvironmentName"] = string.Join(",", EnvironmentNames);
+            tokens["EnvironmentNames"] = string.Join(",", EnvironmentNames);
+            tokens["FunctionsFolderName"] = FunctionsFolderName.to_string();
+            tokens["IndexesFolderName"] = IndexesFolderName.to_string();
+            tokens["Initialize"] = Initialize.to_string();
+            tokens["OutputPath"] = OutputPath.to_string();
+            tokens["PermissionsFolderName"] = PermissionsFolderName.to_string();
+            tokens["RecoveryMode"] = RecoveryMode.to_string();
+            tokens["RepositoryPath"] = RepositoryPath.to_string();
+            tokens["Restore"] = Restore.to_string();
+            tokens["RestoreCustomOptions"] = RestoreCustomOptions.to_string();
+            tokens["RestoreFromPath"] = RestoreFromPath.to_string();
+            tokens["RestoreTimeout"] = RestoreTimeout.to_string();
+            tokens["RunAfterCreateDatabaseFolderName"] = RunAfterCreateDatabaseFolderName.to_string();
+            tokens["RunAfterOtherAnyTimeScriptsFolderName"] = RunAfterOtherAnyTimeScriptsFolderName.to_string();
+            tokens["RunAllAnyTimeScripts"] = RunAllAnyTimeScripts.to_string();
+            tokens["RunBeforeUpFolderName"] = RunBeforeUpFolderName.to_string();
+            tokens["RunFirstAfterUpFolderName"] = RunFirstAfterUpFolderName.to_string();
+            tokens["SchemaName"] = SchemaName.to_string();
+            tokens["ScriptsRunErrorsTableName"] = ScriptsRunErrorsTableName.to_string();
+            tokens["ScriptsRunTableName"] = ScriptsRunTableName.to_string();
+            tokens["SearchAllSubdirectoriesInsteadOfTraverse"] = SearchAllSubdirectoriesInsteadOfTraverse.to_string();
+            tokens["ServerName"] = ServerName.to_string();
+            tokens["Silent"] = Silent.to_string();
+            tokens["SprocsFolderName"] = SprocsFolderName.to_string();
+            tokens["SqlFilesDirectory"] = SqlFilesDirectory.to_string();
+            tokens["TriggersFolderName"] = TriggersFolderName.to_string();
+            tokens["UpFolderName"] = UpFolderName.to_string();
+            tokens["Version"] = Version.to_string();
+            tokens["VersionFile"] = VersionFile.to_string();
+            tokens["VersionTableName"] = VersionTableName.to_string();
+            tokens["VersionXPath"] = VersionXPath.to_string();
+            tokens["ViewsFolderName"] = ViewsFolderName.to_string();
+            tokens["WarnAndIgnoreOnOneTimeScriptChanges"] = WarnAndIgnoreOnOneTimeScriptChanges.to_string();
+            tokens["WarnOnOneTimeScriptChanges"] = WarnOnOneTimeScriptChanges.to_string();
+            tokens["WithTransaction"] = WithTransaction.to_string();
+
+            if (UserTokens != null)
+            {
+                foreach (var t in UserTokens)
+                {
+                    tokens[t.Key] = t.Value;
+                }
+            }
+
+            return tokens;
+        }
+
+    }
 }

--- a/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -68,5 +68,6 @@ namespace roundhouse.infrastructure.app
         Dictionary<string, string> UserTokens { get; set; }
         System.Text.Encoding DefaultEncoding { get; set; }
         string ConfigurationFile { get; set; }
+        IDictionary<string, string> to_token_dictionary();
 	}
 }

--- a/product/roundhouse/infrastructure.app/tokens/TokenReplacer.cs
+++ b/product/roundhouse/infrastructure.app/tokens/TokenReplacer.cs
@@ -1,9 +1,6 @@
 namespace roundhouse.infrastructure.app.tokens
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text.RegularExpressions;
-    using extensions;
 
     public class TokenReplacer
     {
@@ -11,7 +8,7 @@ namespace roundhouse.infrastructure.app.tokens
         {
             if (string.IsNullOrEmpty(text_to_replace)) return string.Empty;
 
-            IDictionary<string, string> dictionary = create_dictionary_from_configuration(configuration);
+            var dictionary = configuration.to_token_dictionary();
             Regex regex = new Regex("{{(?<key>\\w+)}}");
 
             string output = regex.Replace(text_to_replace, m =>
@@ -29,29 +26,6 @@ namespace roundhouse.infrastructure.app.tokens
             });
 
             return output;
-        }
-
-        private static IDictionary<string, string> create_dictionary_from_configuration(ConfigurationPropertyHolder configuration)
-        {
-            Dictionary<string, string> property_dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var property in configuration.GetType().GetProperties())
-            {
-                if (property.Name == "UserTokens")
-                {
-                    var user_tokens = property.GetValue(configuration, null) as Dictionary<string, string>;
-                    if (user_tokens == null)
-                        continue;
-
-                    foreach (var user_token in user_tokens)
-                    {
-                        property_dictionary[user_token.Key] = user_token.Value;
-                    }
-                }
-                else property_dictionary.Add(property.Name, property.GetValue(configuration, null).to_string());
-
-            }
-
-            return property_dictionary;
         }
     }
 }


### PR DESCRIPTION
This will move the creation of the token dictionary out of TokenReplacer and into the ConfigurationPropertyHolder implementation. Along the way, #328 will be fixed.

A few questions:
1. The **roundhouse** project has the C# language version set to 5 - I assume this is intentional but I'd just like to make sure. nameof() and collection initialization are unavailable in C# 5.
2. I've dropped the `DefaultEncoding` and `Logger` properties from the dictionary - are there others that aren't appropriate? They're all primitive types that are at least readable as strings.
3. The `EnvironmentName` key is set to the same value as `EnvironmentNames` (comma-delimited list of environment names) - should it just be the first environment? Or only present if there is a single environment?
4. There are two implementations of `ConfigurationPropertyHolder` - is there any reason the `roundhouse.tasks.Roundhouse` implementation doesn't extend `roundhouse.consoles.DefaultConfiguration` instead of reimplementing the interface?
