### PR TITLE
Performance Improvements (Hashing & Caching)

### DIFF
--- a/product/roundhouse.databases.access/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.access/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,28 @@
+using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.access.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            Table(ApplicationParameters.CurrentMappings.roundhouse_schema_name + "_" + ApplicationParameters.CurrentMappings.scripts_run_errors_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(255);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.mysql/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.mysql/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,28 @@
+﻿using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.mysql.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            Table(ApplicationParameters.CurrentMappings.roundhouse_schema_name + "_" + ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.oracle/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.oracle/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,28 @@
+using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.oracle.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            Table(ApplicationParameters.CurrentMappings.roundhouse_schema_name + "_" + ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Sequence(ApplicationParameters.CurrentMappings.roundhouse_schema_name + "_" + ApplicationParameters.CurrentMappings.scripts_run_table_name + "id").UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.postgresql/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.postgresql/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,26 @@
+﻿using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+
+namespace roundhouse.databases.postgresql.orm
+{
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            Table(ApplicationParameters.CurrentMappings.roundhouse_schema_name + "." + ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Increment().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.sqlite/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.sqlite/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,28 @@
+﻿using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.sqlite.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            Table(ApplicationParameters.CurrentMappings.roundhouse_schema_name + "_" + ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.sqlserver/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.sqlserver/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,29 @@
+using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.sqlserver.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            HibernateMapping.Schema(ApplicationParameters.CurrentMappings.roundhouse_schema_name);
+            Table(ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.sqlserver2000/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.sqlserver2000/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,28 @@
+using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.sqlserver2000.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            Table(ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse.databases.sqlserverce/orm/ScriptsRunCacheMapping.cs
+++ b/product/roundhouse.databases.sqlserverce/orm/ScriptsRunCacheMapping.cs
@@ -1,0 +1,29 @@
+﻿using FluentNHibernate.Mapping;
+using roundhouse.infrastructure;
+using roundhouse.model;
+using System;
+
+namespace roundhouse.databases.sqlserverce.orm
+{
+    [CLSCompliant(false)]
+    public class ScriptsRunCacheMapping : ClassMap<ScriptsRunCache>
+    {
+        public ScriptsRunCacheMapping()
+        {
+            HibernateMapping.Schema(ApplicationParameters.CurrentMappings.roundhouse_schema_name);
+            Table(ApplicationParameters.CurrentMappings.scripts_run_table_name);
+            Not.LazyLoad();
+            HibernateMapping.DefaultAccess.Property();
+            HibernateMapping.DefaultCascade.SaveUpdate();
+
+            Id(x => x.id).Column("id").GeneratedBy.Identity().UnsavedValue(0);
+            Map(x => x.script_name);
+            Map(x => x.text_hash).Length(512);
+
+            //audit
+            Map(x => x.entry_date);
+            Map(x => x.modified_date);
+            Map(x => x.entered_by).Length(50);
+        }
+    }
+}

--- a/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
+++ b/product/roundhouse/infrastructure/persistence/NHibernateSessionFactoryBuilder.cs
@@ -99,6 +99,7 @@ namespace roundhouse.infrastructure.persistence
                 {
                     m.FluentMappings.Add(assembly.GetType(top_namespace + ".orm.VersionMapping", true, true))
                         .Add(assembly.GetType(top_namespace + ".orm.ScriptsRunMapping", true, true))
+                        .Add(assembly.GetType(top_namespace + ".orm.ScriptsRunCacheMapping", true, true))
                         .Add(assembly.GetType(top_namespace + ".orm.ScriptsRunErrorMapping", true, true));
                     //.Conventions.AddAssembly(assembly);
                     //m.HbmMappings.AddFromAssembly(assembly);

--- a/product/roundhouse/model/ScriptsRun.cs
+++ b/product/roundhouse/model/ScriptsRun.cs
@@ -1,19 +1,9 @@
 namespace roundhouse.model
 {
-    using System;
-
-    public class ScriptsRun : Auditable
+    public class ScriptsRun : ScriptsRunCache
     {
-        public long id { get; set; }
         public long version_id { get; set; }
-        public string script_name { get; set; }
         public string text_of_script { get; set; }
-        public string text_hash { get; set; }
         public bool one_time_script { get; set; }
-
-        //auditing
-        public DateTime? entry_date { get; set; }
-        public DateTime? modified_date { get; set; }
-        public string entered_by { get; set; }
     }
 }

--- a/product/roundhouse/model/ScriptsRunCache.cs
+++ b/product/roundhouse/model/ScriptsRunCache.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace roundhouse.model
+{
+    public class ScriptsRunCache : Auditable
+    {
+        public long id { get; set; }
+        public string script_name { get; set; }
+        public string text_hash { get; set; }
+
+        //auditing
+        public DateTime? entry_date { get; set; }
+        public DateTime? modified_date { get; set; }
+        public string entered_by { get; set; }
+    }
+}


### PR DESCRIPTION
* Update default database to trust the cache rather than going to the database on each script check.
Based on my usage running around 2000 scripts on an empty database, this takes off around 6000 database requests
* Update the hash to be a lazy loaded string which reduces the number of times the hash is created
* Update the cached object to not include the full text of the script as it is never read.
This reduces the amount of data required to be loaded from the database
