### PR TITLE
Issue #355: Replace invalid chars in path

### DIFF
--- a/product/roundhouse.tests/infrastructure/filesystem/KnownFolders.cs
+++ b/product/roundhouse.tests/infrastructure/filesystem/KnownFolders.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using roundhouse.consoles;
+using roundhouse.infrastructure.app;
+using roundhouse.infrastructure.app.builders;
+using roundhouse.infrastructure.filesystem;
+
+namespace roundhouse.tests.infrastructure.filesystem
+{
+    [TestFixture()]
+    public class KnownFolders
+    {
+        [Test()]
+        public void should_never_contain_colons()
+        {
+            var config = new DefaultConfiguration
+            {
+                DatabaseName = "DaDatabase",
+                OutputPath = "/tmp/rh",
+                ServerName = "tcp:database.domain.domain"
+            };
+            var fileSystem = new DotNetFileSystemAccess(config);
+
+            var known_folders = KnownFoldersBuilder.build(fileSystem, config);
+            
+            StringAssert.DoesNotContain(":", known_folders.change_drop.folder_full_path);
+        }
+        
+    }
+}

--- a/product/roundhouse/infrastructure.app/builders/KnownFoldersBuilder.cs
+++ b/product/roundhouse/infrastructure.app/builders/KnownFoldersBuilder.cs
@@ -28,8 +28,8 @@ namespace roundhouse.infrastructure.app.builders
             Folder change_drop_folder = new DefaultFolder(file_system, combine_items_into_one_path(file_system,
                                                                                                    configuration_property_holder.OutputPath,
                                                                                                    "migrations",
-                                                                                                   remove_paths_from(configuration_property_holder.DatabaseName,file_system),
-                                                                                                   remove_paths_from(configuration_property_holder.ServerName,file_system)),
+                                                                                                   remove_invalid_characters_from(configuration_property_holder.DatabaseName,file_system),
+                                                                                                   remove_invalid_characters_from(configuration_property_holder.ServerName,file_system)),
                                                           get_run_date_time_string());
 
 			return new DefaultKnownFolders(
@@ -58,6 +58,11 @@ namespace roundhouse.infrastructure.app.builders
         private static string remove_paths_from(string name, FileSystemAccess file_system)
         {
             return file_system.get_file_name_without_extension_from(name);
+        }
+        
+        private static string remove_invalid_characters_from(string path_segment, FileSystemAccess file_system)
+        {
+            return file_system.remove_invalid_characters_from(path_segment);
         }
 
         private static string get_run_date_time_string()

--- a/product/roundhouse/infrastructure/filesystem/DotNetFileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/DotNetFileSystemAccess.cs
@@ -25,6 +25,7 @@ namespace roundhouse.infrastructure.filesystem
         }
 
         private ConfigurationPropertyHolder configuration;
+        private static readonly char[] InvalidPathCharacters = Path.GetInvalidPathChars().Append(':').ToArray();
 
 
         #region File
@@ -247,6 +248,16 @@ namespace roundhouse.infrastructure.filesystem
         public string get_file_name_without_extension_from(string file_path)
         {
             return Path.GetFileNameWithoutExtension(file_path);
+        }
+
+        public string remove_invalid_characters_from(string path_segment)
+        {
+            foreach (var c in InvalidPathCharacters)
+            {
+                path_segment = path_segment.Replace(c, '_');
+            }
+
+            return path_segment;
         }
 
         /// <summary>

--- a/product/roundhouse/infrastructure/filesystem/FileSystemAccess.cs
+++ b/product/roundhouse/infrastructure/filesystem/FileSystemAccess.cs
@@ -109,6 +109,14 @@ namespace roundhouse.infrastructure.filesystem
         /// <param name="file_path">Full path to file including file name</param>
         /// <returns>Returns only the file name minus extensions from the filepath</returns>
         string get_file_name_without_extension_from(string file_path);
+        
+        /// <summary>
+        /// Removes invalid characters from a path segment
+        /// </summary>
+        /// <param name="path_segment">segment of path to clean</param>
+        /// <returns>The path with all illegal characters stripped away</returns>
+        string remove_invalid_characters_from(string path_segment);
+        
 
         /// <summary>
         /// Determines the file extension for a given path to a file


### PR DESCRIPTION
Make sure there are no invalid paths in the folder used to log migrations. Currently filters out `Path.GetInvalidChars()` and `:`. Maybe not necessary to explicitly exclude a colon, as it is valid on other platforms than Windows, but, anyways... makes the directories more unified across platforms.