### PR TITLE
Add docker distribution of RoundhousE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:2.2-sdk
 
-MAINTAINER erik@brandstadmoen.net
+LABEL maintainer="erik@brandstadmoen.net"
 
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet tool install dotnet-roundhouse -g

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM microsoft/dotnet:2.2-sdk
+
+MAINTAINER erik@brandstadmoen.net
+
+ENV PATH="$PATH:/root/.dotnet/tools"
+RUN dotnet tool install dotnet-roundhouse -g
+
+ENTRYPOINT [ "rh" ]

--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,10 @@ You will need dotnet core installed on your box for this to work. You can get it
 
 ### Docker: Dotnet core global tool
 
-1. docker pull dotnetroundhouse/roundhouse
+You can easily integrate RoundhousE in your existing docker infrastructure. Use docker compose, or just pull it down directly and run it. Yopu should probably build upon the image, and add your own customisations, as appropriate. The docker image has the dotnet core global tool distribution of RoundhousE in a Alpine Linux bases container.
+
+1. Type `docker pull dotnetroundhouse/roundhouse`
+1. Type `docker run dotnetroundhouse/roundhouse`
 
  
 ### Source

--- a/README.markdown
+++ b/README.markdown
@@ -67,6 +67,12 @@ https://natemcmaster.com/blog/2018/05/12/dotnet-global-tools/, but in short, it 
 the binaries to your `~/.dotnet/tools` folder. 
 
 You will need dotnet core installed on your box for this to work. You can get it here: [https://dot.net](https://dot.net).
+
+
+### Docker: Dotnet core global tool
+
+1. docker pull dotnetroundhouse/roundhouse
+
  
 ### Source
 This is the best way to get to the bleeding edge of what we are doing.  


### PR DESCRIPTION
Added Dockerfile, which installs `dotnet-roundhouse` on a Microsoft 2.2. sdk .net core sdk image.

Fixes #342 