### PR TITLE
Version roundhouse in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM microsoft/dotnet:2.2-sdk
 
 LABEL maintainer="erik@brandstadmoen.net"
 
+ARG roundhouse_version
+
 ENV PATH="$PATH:/root/.dotnet/tools"
-RUN dotnet tool install dotnet-roundhouse -g --version 1.0.4
+RUN dotnet tool install dotnet-roundhouse -g --version $roundhouse_version
 
 ENTRYPOINT [ "rh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM microsoft/dotnet:2.2-sdk
 LABEL maintainer="erik@brandstadmoen.net"
 
 ENV PATH="$PATH:/root/.dotnet/tools"
-RUN dotnet tool install dotnet-roundhouse -g
+RUN dotnet tool install dotnet-roundhouse -g --version 1.0.4
 
 ENTRYPOINT [ "rh" ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 image: Visual Studio 2017
 
+services:
+- docker
+
 install:
   - choco install gitversion.portable -y
 
@@ -8,13 +11,13 @@ before_build:
 
 build_script:
   - ps: .\build.ps1
-  
+
 test:
   assemblies:
     only:
       - '**\*tests.dll'
 
-      
+
 artifacts:
   - path: .\code_drop\packages\*.nupkg
     name: Nuget packages
@@ -26,6 +29,11 @@ deploy:
   server:  https://www.myget.org/F/roundhouse/api/v2/package
   api_key:
     secure: XWER/H0IkJ8JWFm+n3/lr7hHoNFAX/VpRD+AfpZo2EUgQkQKhrMxHa4aYZPogsvY
-  skip_symbols: true 
+  skip_symbols: true
   artifact: /.*\.nupkg/
   disable_publish_on_pr: true
+
+deploy_script:
+  - docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+  - docker push dotnetroundhouse/roundhouse:latest
+  - docker push dotnetroundhouse/roundhouse:"$env:APPVEYOR_BUILD_VERSION"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ deploy:
 deploy_script:
   - docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
   - docker push dotnetroundhouse/roundhouse:latest
-  - docker push dotnetroundhouse/roundhouse:"$env:APPVEYOR_BUILD_VERSION"
+  - docker push dotnetroundhouse/roundhouse:"$env:GitVersion_FullSemVer"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,4 @@ deploy:
 deploy_script:
   - docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
   - docker push dotnetroundhouse/roundhouse:latest
-  - docker push dotnetroundhouse/roundhouse:"$env:GitVersion_FullSemVer"
+  - docker push dotnetroundhouse/roundhouse:"$env:APPVEYOR_BUILD_VERSION"

--- a/build.ps1
+++ b/build.ps1
@@ -47,7 +47,7 @@ msbuild /t:"Build" /p:DropFolder=$CODEDROP /p:Version="$($gitVersion.FullSemVer)
 
 "`n    - Packaging net461 packages`n"
 
-nuget pack product/roundhouse.console/roundhouse.nuspec -OutputDirectory "$CODEDROP/packages" -Properties "mergedExe=$CODEDROP/merge/rh.exe" -Verbosity quiet -NoPackageAnalysis -Version "$($gitVersion.FullSemVer)" 
+nuget pack product/roundhouse.console/roundhouse.nuspec -OutputDirectory "$CODEDROP/packages" -Properties "mergedExe=$CODEDROP/merge/rh.exe" -Verbosity quiet -NoPackageAnalysis -Version "$($gitVersion.FullSemVer)"
 msbuild /t:"Pack" product/roundhouse.lib.merged/roundhouse.lib.merged.csproj  /p:DropFolder=$CODEDROP /p:Version="$($gitVersion.FullSemVer)" /p:NoPackageAnalysis=true /nologo /v:q /fl /flp:"LogFile=$LOGDIR/msbuild.roundhouse.lib.pack.log;Verbosity=n" /p:Configuration=Build /p:Platform="Any CPU"
 msbuild /t:"Pack" product/roundhouse.tasks/roundhouse.tasks.csproj  /p:DropFolder=$CODEDROP /p:Version="$($gitVersion.FullSemVer)" /p:NoPackageAnalysis=true /nologo /v:q /fl /flp:"LogFile=$LOGDIR/msbuild.roundhouse.tasks.pack.log;Verbosity=n" /p:Configuration=Build /p:Platform="Any CPU"
 
@@ -56,8 +56,11 @@ msbuild /t:"Pack" product/roundhouse.tasks/roundhouse.tasks.csproj  /p:DropFolde
 dotnet publish -v q --no-restore product/roundhouse.console -p:Version="$($gitVersion.FullSemVer)" -p:NoPackageAnalysis=true -p:TargetFramework=netcoreapp2.1 -p:Version="$($gitVersion.FullSemVer)" -p:RunILMerge=false -p:Configuration=Build -p:Platform="Any CPU"
 dotnet pack -v q --no-restore product/roundhouse.console -p:NoPackageAnalysis=true -p:TargetFramework=netcoreapp2.1 -o $CODEDROP/packages -p:Version="$($gitVersion.FullSemVer)" -p:RunILMerge=false -p:Configuration=Build -p:Platform="Any CPU"
 
+"`n    - Building docker image`n"
 
-# AppVeyor runs the test automagically, no need to run explicitly with nunit-console.exe. 
+docker build --build-arg roundhouse_version="$($gitVersion.FullSemVer)" . -t dotnetroundhouse/roundhouse:latest -t dotnetroundhouse/roundhouse:$gitVersion.FullSemVer
+
+# AppVeyor runs the test automagically, no need to run explicitly with nunit-console.exe.
 # But we want to run the tests on localhost too.
 If (! $onAppVeyor) {
 

--- a/build.ps1
+++ b/build.ps1
@@ -58,7 +58,7 @@ dotnet pack -v q --no-restore product/roundhouse.console -p:NoPackageAnalysis=tr
 
 "`n    - Building docker image`n"
 
-docker build --build-arg roundhouse_version="$($gitVersion.FullSemVer)" . -t dotnetroundhouse/roundhouse:latest -t dotnetroundhouse/roundhouse:$gitVersion.FullSemVer
+docker build --build-arg roundhouse_version="$($gitVersion.FullSemVer)" . -t dotnetroundhouse/roundhouse:latest -t dotnetroundhouse/roundhouse:"$($gitVersion.FullSemVer)"
 
 # AppVeyor runs the test automagically, no need to run explicitly with nunit-console.exe.
 # But we want to run the tests on localhost too.


### PR DESCRIPTION
Hi @erikbra,

I thought I might just create a PR with some suggestions for improvements on the docker image definition. Of note are the following changes:

- Add an explicit version to `RUN dotnet tool install dotnet-roundhouse -g --version $roundhouse_version` - this is the most important change. It pins the version of RoundhousE in the image so that consumers of the image definition can depend on the right version of RoundhousE being present in their containers
- Pass in the version during image build time with an `ARG` command
- Build the image in `build.ps1`, and create a "latest" and a versioned tag for the image
- Add some AppVeyor lines that might push the final images to DockerHub?

Unfortunately, since I normally develop on a Linux host at home, I can't easily test out the update to the build script without a reboot into Windows. Normally, I don't open a PR without some testing of my own, but the amount of work involved in getting my Windows environment into a build-ready environment shied me away from waiting that long to open this PR.

Beyond testing the build, I'm not sure how I could test out the AppVeyor changes. I am concerned that the changes could break other pieces of the AppVeyor build, but that mostly stems from complete inexperience with AppVeyor! Also, a couple of environment variables would need to be set (by you or another maintainer, I'd presume) in order for the push to DockerHub to work.

Thanks!