### PR TITLE
Updated parser to handle single quoted values

### DIFF
--- a/product/roundhouse.databases.mysql/parser/Scanner.cs
+++ b/product/roundhouse.databases.mysql/parser/Scanner.cs
@@ -151,8 +151,12 @@ namespace roundhouse.databases.mysql.parser
                         AnsiQuoted();
                         break;
                     } else {
-                        goto case '`';
+                        goto case '\'';
                     }
+
+                case '\'':
+                    SingleQuoted();
+                    break;
 
                 case '`':
                     Quoted();
@@ -285,12 +289,32 @@ namespace roundhouse.databases.mysql.parser
 
                 if (IsAtEnd()) {
                     // unterminated string
-                    throw new ParserException("Unterminated quoted value on line " + line);
+                    throw new ParserException("Unterminated double quoted value on line " + line);
                 }
             }
 
             Advance(); // closing quote
             AddToken(Token.Type.AnsiQuote);
+        }
+
+        private void SingleQuoted()
+        {
+            while (!IsAtEnd() && !IsSingleQuote(Peek())) {
+                
+                if (Peek() == '\n') {
+                    line++;
+                }
+
+                Advance();
+
+                if (IsAtEnd()) {
+                    // unterminated string
+                    throw new ParserException("Unterminated single quoted value on line " + line);
+                }
+            }
+
+            Advance(); // closing quote
+            AddToken(Token.Type.SingleQuote);
         }
 
         private void General()
@@ -391,6 +415,11 @@ namespace roundhouse.databases.mysql.parser
         private static bool IsAnsiQuote(char c) 
         {
             return c == '"';
+        }
+
+        private static bool IsSingleQuote(char c)
+        {
+            return c == '\'';
         }
 
         private void DelimiterDeclaration() {

--- a/product/roundhouse.databases.mysql/parser/Token.cs
+++ b/product/roundhouse.databases.mysql/parser/Token.cs
@@ -15,6 +15,7 @@ namespace roundhouse.databases.mysql.parser
             Text,              // SQL script text
             Quote,             // quoted text
             AnsiQuote,         // ANSI quoted text
+            SingleQuote,       // Single quited text
             Whitespace,        // whitespace
             EndOfLine,         // end of line
             EndOfFile          // end of file

--- a/product/roundhouse.tests/sqlsplitters/MySqlStatementSplitterSpecs.cs
+++ b/product/roundhouse.tests/sqlsplitters/MySqlStatementSplitterSpecs.cs
@@ -33,7 +33,7 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(2, statements.Count);
             }
@@ -60,7 +60,7 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(2, statements.Count);
             }
@@ -74,7 +74,7 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(2, statements.Count);
             }
@@ -88,7 +88,7 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(2, statements.Count);
             }
@@ -102,7 +102,7 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(2, statements.Count);
             }
@@ -116,7 +116,7 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(2, statements.Count);
             }
@@ -130,21 +130,40 @@ namespace roundhouse.tests.sqlsplitters
                 List<ParsedStatement> statements = parser.Parse();
                 WriteStatements(statements);
 
-                TestContext.Out.WriteLine("Statements parsed: " + statements.Count);
+                WriteOutput("Statements parsed: " + statements.Count);
                 Assert.AreEqual("select * from test1" + Environment.NewLine, statements[0].Value);
+                Assert.AreEqual(3, statements.Count);
+            }
+
+            [Observation]
+            public void should_honor_quoted_semicolon()
+            {
+                string script = "set ps = 'select * from test;';\nprepare ps;\nexecute ps;";
+
+                Parser parser = new Parser(script);
+                List<ParsedStatement> statements = parser.Parse();
+                WriteStatements(statements);
+
+                WriteOutput("Statements parsed: " + statements.Count);
+                Assert.AreEqual("set ps = 'select * from test;'" + Environment.NewLine, statements[0].Value);
                 Assert.AreEqual(3, statements.Count);
             }
 
             private void WriteStatements(List<ParsedStatement> statements) {
                 int index = 0;
                 foreach (ParsedStatement statement in statements) {
-                    TestContext.Out.WriteLine(index + ":");
+                    WriteOutput(index + ":");
                     WriteStatement(statement);
                     index++;
                 }
             }
+
             private void WriteStatement(ParsedStatement statement) {
-                TestContext.Out.Write(statement.Value);
+                WriteOutput(statement.Value);
+            }
+
+            private void WriteOutput(string value) {
+                //NUnit.Framework.TestContext.Progress.WriteLine(value);
             }
         }
     }


### PR DESCRIPTION
I ran into an issue this week and it turns out (much to my embarrassment) that the MySQL parser doesn't handle single (') quoted values, only back-tick or double quoted. This change adds single quoted values to the parser. It also adds a new test case for single quoted values.

I have another project where I test these changes against a database, you can find a [more practical example there](https://github.com/cmiles74/rh-mysql-sproc-test/blob/master/up/0003_Parsed_Statement.sql).

Thank you! `:-D`