### PR TITLE
Fix EOL-related hash comparison bug

### DIFF
--- a/product/roundhouse.core/infrastructure.app/ApplicationConfiguraton.cs
+++ b/product/roundhouse.core/infrastructure.app/ApplicationConfiguraton.cs
@@ -182,7 +182,8 @@ namespace roundhouse.infrastructure.app
             var known_folders = KnownFoldersBuilder.build(file_system, configuration_property_holder);
             var log_factory = new MultipleLoggerLogFactory();
             var crypto_service = new MD5CryptographicService();
-            var db_migrator = new DefaultDatabaseMigrator(database, crypto_service, configuration_property_holder);
+            var hash_generator = new DefaultHashGenerator(crypto_service);
+            var db_migrator = new DefaultDatabaseMigrator(database, hash_generator, configuration_property_holder);
             var version_resolver = VersionResolverBuilder.build(file_system, configuration_property_holder);
             var environment_set = new DefaultEnvironmentSet(configuration_property_holder);
             var initializer = new FileSystemInitializer(known_folders);

--- a/product/roundhouse.core/migrators/DefaultHashGenerator.cs
+++ b/product/roundhouse.core/migrators/DefaultHashGenerator.cs
@@ -12,10 +12,12 @@ namespace roundhouse.migrators
         private const string MacLineEnding = "\r";
 
         private readonly CryptographicService crypto_provider;
+        private readonly IReadOnlyCollection<string> line_ending_variations;
 
         public DefaultHashGenerator(CryptographicService crypto_provider)
         {
             this.crypto_provider = crypto_provider;
+            this.line_ending_variations = new List<string> { WindowsLineEnding, UnixLineEnding, MacLineEnding };
         }
 
         public string create_hash(string sql_to_run, bool normalizeEndings)
@@ -55,10 +57,8 @@ namespace roundhouse.migrators
 
         private bool have_same_hash_ignoring_platform(string sql_to_run, string old_text_hash)
         {
-            var lineEndingVariations = new List<string> {WindowsLineEnding, UnixLineEnding, MacLineEnding};
-
-            return lineEndingVariations.Any(variation => {
-                var normalized_sql = lineEndingVariations.Aggregate(sql_to_run, (norm, ending) => norm.Replace(ending, variation));
+            return line_ending_variations.Any(variation => {
+                var normalized_sql = line_ending_variations.Aggregate(sql_to_run, (norm, ending) => norm.Replace(ending, variation));
                 return hashes_are_equal(create_hash(normalized_sql, false), old_text_hash);
             });
         }

--- a/product/roundhouse.core/migrators/DefaultHashGenerator.cs
+++ b/product/roundhouse.core/migrators/DefaultHashGenerator.cs
@@ -1,0 +1,66 @@
+namespace roundhouse.migrators
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using cryptography;
+    using infrastructure.logging;
+
+    public sealed class DefaultHashGenerator : HashGenerator
+    {
+        private const string WindowsLineEnding = "\r\n";
+        private const string UnixLineEnding = "\n";
+        private const string MacLineEnding = "\r";
+
+        private readonly CryptographicService crypto_provider;
+
+        public DefaultHashGenerator(CryptographicService crypto_provider)
+        {
+            this.crypto_provider = crypto_provider;
+        }
+
+        public string create_hash(string sql_to_run, bool normalizeEndings)
+        {
+            var input = sql_to_run.Replace(@"'", @"''");
+            if (normalizeEndings)
+                input = input.Replace(WindowsLineEnding, UnixLineEnding).Replace(MacLineEnding, UnixLineEnding);
+            return crypto_provider.hash(input);
+        }
+
+        public bool have_same_hash(string script_name, string sql_to_run, string old_text_hash)
+        {
+            // These check hashes from before the normalization change and after
+            // The change does result in a different hash that will not be the result of
+            // any sore of file change and therefore should not be logged.
+            bool hash_is_same =
+                hashes_are_equal(create_hash(sql_to_run, true), old_text_hash) ||   // New hash
+                hashes_are_equal(create_hash(sql_to_run, false), old_text_hash);    // Old hash
+
+            if (!hash_is_same)
+            {
+                // extra checks if only line endings have changed
+                hash_is_same = have_same_hash_ignoring_platform(sql_to_run, old_text_hash);
+                if (hash_is_same)
+                {
+                    Log.bound_to(this).log_a_warning_event_containing("Script {0} had different line endings than before but equal content", script_name);
+                }
+            }
+
+            return hash_is_same;
+        }
+
+        private bool hashes_are_equal(string new_text_hash, string old_text_hash)
+        {
+            return string.Compare(old_text_hash, new_text_hash, true) == 0;
+        }
+
+        private bool have_same_hash_ignoring_platform(string sql_to_run, string old_text_hash)
+        {
+            var lineEndingVariations = new List<string> {WindowsLineEnding, UnixLineEnding, MacLineEnding};
+
+            return lineEndingVariations.Any(variation => {
+                var normalized_sql = lineEndingVariations.Aggregate(sql_to_run, (norm, ending) => norm.Replace(ending, variation));
+                return hashes_are_equal(create_hash(normalized_sql, false), old_text_hash);
+            });
+        }
+    }
+}

--- a/product/roundhouse.core/migrators/HashGenerator.cs
+++ b/product/roundhouse.core/migrators/HashGenerator.cs
@@ -1,0 +1,8 @@
+namespace roundhouse.migrators
+{
+    public interface HashGenerator
+    {
+        string create_hash(string sql_to_run, bool normalizeEndings);
+        bool have_same_hash(string script_name, string sql_to_run, string old_text_hash);
+    }
+}

--- a/product/roundhouse.tests/migrators/DefaultHashGeneratorSpecs.cs
+++ b/product/roundhouse.tests/migrators/DefaultHashGeneratorSpecs.cs
@@ -1,0 +1,126 @@
+﻿using roundhouse.cryptography;
+using roundhouse.migrators;
+using Should;
+
+namespace roundhouse.tests.migrators
+{
+    public class when_comparing_hashes
+    {
+        public abstract class concern_for_hash_generator : TinySpec<DefaultHashGenerator>
+        {
+            protected const string script_text_with_cr = "line1\rline2";
+            protected const string script_text_with_lf = "line1\nline2";
+            protected const string script_text_with_crlf = "line1\r\nline2";
+            protected const string another_script = "lineA\r\nlineB";
+            protected string hash_of_script_text_with_cr;
+            protected string hash_of_script_text_with_lf;
+            protected string hash_of_script_text_with_crlf;
+            protected string hash_of_another_script;
+
+            private CryptographicService crypto_service;
+            private DefaultHashGenerator default_hash_generator;
+
+            protected concern_for_hash_generator()
+            {
+                crypto_service = new MD5CryptographicService();
+                default_hash_generator = new DefaultHashGenerator(crypto_service);
+            }
+
+            public override void Context()
+            {
+                hash_of_script_text_with_cr = crypto_service.hash(script_text_with_cr);
+                hash_of_script_text_with_lf = crypto_service.hash(script_text_with_lf);
+                hash_of_script_text_with_crlf = crypto_service.hash(script_text_with_crlf);
+                hash_of_another_script = crypto_service.hash(another_script);
+            }
+
+            public override void Because() { }
+
+            protected override DefaultHashGenerator sut
+            {
+                get { return default_hash_generator; }
+                set { default_hash_generator = value; }
+            }
+        }
+
+        [Concern(typeof(DefaultHashGenerator))]
+        public class when_only_line_endings_change : concern_for_hash_generator
+        {
+            [Observation]
+            public void if_old_and_new_files_have_CR_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_cr, hash_of_script_text_with_cr).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_and_new_files_have_LF_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_lf, hash_of_script_text_with_lf).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_and_new_files_have_CRLF_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_crlf, hash_of_script_text_with_crlf).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_file_has_CR_and_new_file_has_LF_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_lf, hash_of_script_text_with_cr).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_file_has_CR_and_new_file_has_CRLF_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_crlf, hash_of_script_text_with_cr).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_file_has_LF_and_new_file_has_CR_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_cr, hash_of_script_text_with_lf).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_file_has_LF_and_new_file_has_CRLF_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_crlf, hash_of_script_text_with_lf).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_file_has_CRLF_and_new_file_has_CR_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_cr, hash_of_script_text_with_crlf).ShouldBeTrue();
+            }
+
+            [Observation]
+            public void if_old_file_has_CRLF_and_new_file_has_LF_should_return_true()
+            {
+                sut.have_same_hash("file.sql", script_text_with_lf, hash_of_script_text_with_crlf).ShouldBeTrue();
+            }
+        }
+
+        [Concern(typeof(DefaultHashGenerator))]
+        public class when_script_text_changes : concern_for_hash_generator
+        {
+            [Observation]
+            public void if_new_file_has_CR_should_return_false()
+            {
+                sut.have_same_hash("file.sql", script_text_with_cr, hash_of_another_script).ShouldBeFalse();
+            }
+
+            [Observation]
+            public void if_new_file_has_LF_should_return_false()
+            {
+                sut.have_same_hash("file.sql", script_text_with_lf, hash_of_another_script).ShouldBeFalse();
+            }
+
+            [Observation]
+            public void if_new_file_has_CRLF_should_return_false()
+            {
+                sut.have_same_hash("file.sql", script_text_with_crlf, hash_of_another_script).ShouldBeFalse();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hash comparison should ignore end-of-line variations, but it fails in one scenario:
 - when the original hash was calculated by an older RH version, which didn't normalize the script to LF line endings before hashing
 - and the original script had CRLF line endings
 - and the same file, but with LF line endings, is executed by the migrator.

This PR refactors hash generation and comparison into a separate class, adds unit tests that demonstrate the bug and fixes it.