### PR TITLE
Locked GitVersion to 4.0.0 in appveyor.yml 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2019
 
 install:
-  - choco install gitversion.portable -y
+  - choco install gitversion.portable --version 4.0.0 -y
 
 before_build:
   - ps: gitversion /l console /output buildserver


### PR DESCRIPTION
Due to error running latest GitVersion on AppVeyor.

Got the following error with latest (5.0.1): Unrecognized configuration section dllmap