### PR TITLE
Order directories by path

### DIFF
--- a/product/roundhouse.core/infrastructure/filesystem/DotNetFileSystemAccess.cs
+++ b/product/roundhouse.core/infrastructure/filesystem/DotNetFileSystemAccess.cs
@@ -370,7 +370,7 @@ namespace roundhouse.infrastructure.filesystem
         /// <returns>A list of subdirectories inside of the existing directory</returns>
         public string[] get_all_directory_name_strings_in(string directory)
         {
-            return Directory.GetDirectories(directory);
+            return Directory.GetDirectories(directory).OrderBy(d => d).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
As seen in #386 directories are not ordered when they're retrieved. This results in different behaviour when executing up scripts on windows vs linux (assuming it's actually different due to the way the different filesystems work under the hood).

This adds an option to force the directories to be retrieved in order so that scripts run in a repeatable manner. The config defaults to false to avoid breaking any existing executions based on the old behaviour.

![image](https://user-images.githubusercontent.com/4455918/66865707-4a5a4780-eff4-11e9-8a2c-dcdab06afe02.png)
Running `Directory.GetDirectories(upPath)` on windows vs linux