### PR TITLE
Adding System.ValueTuple dependency

### DIFF
--- a/product/roundhouse.core/roundhouse.core.csproj
+++ b/product/roundhouse.core/roundhouse.core.csproj
@@ -71,6 +71,7 @@ This is the core package, which implements the basic functionality. If you want 
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.5.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="infrastructure.app\logging\log4net.config.xml" />


### PR DESCRIPTION
It would appear that this is now used as part of https://github.com/chucknorris/roundhouse/pull/388/files#diff-3139d803d9b04a25c7e3beaa80e76f4cR16
When consuming this in a framework project, this dependency is required