### PR TITLE
Add Access Token support to SqlServerDatabase

### DIFF
--- a/product/roundhouse.console/Program.cs
+++ b/product/roundhouse.console/Program.cs
@@ -133,6 +133,9 @@ namespace roundhouse.console
                      string.Format(
                          "ConnectionStringAdministration - This is used for connecting to master when you may have a different uid and password than normal."),
                      option => configuration.ConnectionStringAdmin = option)
+                .Add("accesstoken=",
+                     "AccessToken - This connection property is used to connect to a SQL Database using an access token (for example Azure AD token).",
+                     option => configuration.AccessToken = option)
                 .Add("ct=|commandtimeout=",
                      string.Format(
                          "CommandTimeout - This is the timeout when commands are run. This is not for admin commands or restore. Defaults to \"{0}\".",
@@ -398,6 +401,7 @@ namespace roundhouse.console
                         "/[sql]f[ilesdirectory] VALUE " +
                         "/s[ervername] VALUE " +
                         "/c[onnection]s[tring]a[dministration] VALUE " +
+                        "/accesstoken VALUE " +
                         "/c[ommand]t[imeout] VALUE /c[ommand]t[imeout]a[dmin] VALUE " +
                         "/r[epositorypath] VALUE /v[ersion] VALUE /v[ersion]f[ile] VALUE /v[ersion]x[path] VALUE " +
                         "/a[lter]d[atabasefoldername] /r[un]a[fter]c[reate]d[atabasefoldername] VALUE VALUE " +

--- a/product/roundhouse.core/consoles/DefaultConfiguration.cs
+++ b/product/roundhouse.core/consoles/DefaultConfiguration.cs
@@ -20,6 +20,7 @@ namespace roundhouse.consoles
         public string DatabaseName { get; set; }
         public string ConnectionString { get; set; }
         public string ConnectionStringAdmin { get; set; }
+        public string AccessToken { get; set; }
         public int CommandTimeout { get; set; }
         public int CommandTimeoutAdmin { get; set; }
         public string SqlFilesDirectory { get; set; }
@@ -89,6 +90,7 @@ namespace roundhouse.consoles
         public IDictionary<string, string> to_token_dictionary()
         {
             var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            tokens["AccessToken"] = AccessToken.to_string();
             tokens["AfterMigrationFolderName"] = AfterMigrationFolderName.to_string();
             tokens["AlterDatabaseFolderName"] = AlterDatabaseFolderName.to_string();
             tokens["Baseline"] = Baseline.to_string();

--- a/product/roundhouse.core/infrastructure.app/ConfigurationPropertyHolder.cs
+++ b/product/roundhouse.core/infrastructure.app/ConfigurationPropertyHolder.cs
@@ -14,6 +14,7 @@ namespace roundhouse.infrastructure.app
         string DatabaseName { get; set; }
         string ConnectionString { get; set; }
         string ConnectionStringAdmin { get; set; }
+        string AccessToken { get; set; }
         int CommandTimeout { get; set; }
         int CommandTimeoutAdmin { get; set; }
         string SqlFilesDirectory { get; set; }

--- a/product/roundhouse.databases.sqlserver/ReliableSqlConnection.cs
+++ b/product/roundhouse.databases.sqlserver/ReliableSqlConnection.cs
@@ -28,7 +28,8 @@ namespace roundhouse.databases.sqlserver
         private readonly RetryPolicy connection_string_failover_policy = get_default_retry_policy();
         
         private string connection_string;
-        
+        private string access_token;
+
        
         private static RetryPolicy get_default_retry_policy()
         {
@@ -96,6 +97,19 @@ namespace roundhouse.databases.sqlserver
             {
                 connection_string = value;
                 underlying_connection.ConnectionString = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the access token for a connection
+        /// </summary>
+        public string AccessToken
+        {
+            get => access_token;
+            set
+            {
+                access_token = value;
+                underlying_connection.AccessToken = value;
             }
         }
 

--- a/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
+++ b/product/roundhouse.databases.sqlserver/SqlServerDatabase.cs
@@ -35,6 +35,7 @@ namespace roundhouse.databases.sqlserver
 
         private string connect_options = "Integrated Security=SSPI;";
         private readonly TransientErrorDetectionStrategy error_detection_strategy = new TransientErrorDetectionStrategy();
+        private string access_token;
 
         public override string sql_statement_separator_regex_pattern
         {
@@ -50,6 +51,8 @@ namespace roundhouse.databases.sqlserver
 
         public override void initialize_connections(ConfigurationPropertyHolder configuration_property_holder)
         {
+            access_token = configuration_property_holder.AccessToken;
+
             if (!string.IsNullOrEmpty(connection_string))
             {
                 var connection_string_builder = new SqlConnectionStringBuilder(connection_string);
@@ -102,6 +105,10 @@ namespace roundhouse.databases.sqlserver
             var command_retry_policy = Policy.Handle<Exception>().Retry(0);
 
             var connection = new ReliableSqlConnection(conn_string, connection_retry_policy, command_retry_policy);
+            if (!string.IsNullOrEmpty(access_token))
+            {
+                connection.AccessToken = access_token;
+            }
 
             connection_specific_setup(connection);
             return new AdoNetConnection(connection);

--- a/product/roundhouse.tasks/Roundhouse.cs
+++ b/product/roundhouse.tasks/Roundhouse.cs
@@ -60,6 +60,8 @@ namespace roundhouse.tasks
 
         public string ConnectionStringAdmin { get; set; }
 
+        public string AccessToken { get; set; }
+
         public int CommandTimeout { get; set; }
 
         public int CommandTimeoutAdmin { get; set; }
@@ -214,6 +216,7 @@ namespace roundhouse.tasks
         {
             var tokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
+                { nameof(AccessToken), AccessToken.to_string() },
                 { nameof(AfterMigrationFolderName), AfterMigrationFolderName.to_string() },
                 { nameof(AlterDatabaseFolderName), AlterDatabaseFolderName.to_string() },
                 { nameof(Baseline), Baseline.to_string() },


### PR DESCRIPTION
Added support for access tokens for use in Azure SQL.

Unfortunately, I'm unable to test this against Azure. I did test against a local SQL Server instance and the property is set on the underlying connection.

Possibly fixes #344 and #343 