### PR TITLE
Fix Dockerfile to honor arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
 WORKDIR /app
 COPY --from=build-env /app/out .
 
-ENTRYPOINT dotnet rh.dll
+ENTRYPOINT ["dotnet", "rh.dll"]


### PR DESCRIPTION
Change the ENTRYPOINT to array syntax in order to allow passing parameters to rh from docker run.
This should fix issue #414 