### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY . ./
 
 RUN dotnet publish -v q -nologo --no-restore product/roundhouse.console -o /app/out -p:TargetFramework=netcoreapp2.1 -p:Version="${VERSION}" -p:Configuration=Build -p:Platform="Any CPU"
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
 WORKDIR /app
 COPY --from=build-env /app/out .


### PR DESCRIPTION
This fixes the runtime .NET Core image to bring it into line with the SDK image. That's to say, the code is built in SDK 3.1, so the runtime should be 3.1 also.