### PR TITLE
Fix dot net tool packaging path

### DIFF
--- a/product/roundhouse.console/roundhouse.tool.nuspec
+++ b/product/roundhouse.console/roundhouse.tool.nuspec
@@ -21,7 +21,7 @@
     <icon>images/RoundhousE_Logo.NuGet.jpg</icon>
   </metadata>
   <files>
-    <file src="bin/netcoreapp2.1/publish/**/**" target="tools/netcoreapp2.1/any" />
+    <file src="bin\netcoreapp2.1\publish\**\**" target="tools\netcoreapp2.1\any" />
     <file src="../../nuget/RoundhousE_Logo.NuGet.jpg" target="images/" />
   </files>
 </package>


### PR DESCRIPTION
Currently [this bug](https://github.com/chucknorris/roundhouse/issues/421) is open where the latest dotnet tool install for Roundhouse does not currently work due to it not finding the `DotNetToolSettings.xml` file. This was due to a change with the file path in the tool nuspec file where backslashes were swapped for forward slashes, which led to the directory structure of the tool package changing and nesting files deeper inside the structure of the package. As you can see in the below screenshot, changing the forward slashes to a backslashes restores the directory structure where the contents can be found under the `tools\.netcoreapp2.1\any\` folder (on the right) instead of under `tools\netcoreapp2.1\any\bin\netcoreapp2.1\publish`  (on the left). With this new directory structure, the `DotNetToolSettings.xml` file can be found directly under the `any` folder now, which should alleviate the error currently being seen.

![image](https://user-images.githubusercontent.com/1013553/124678343-f22e3d80-de87-11eb-9129-c07458ca7b41.png)

I tested this change in both Windows where I originally made the change and in Ubuntu in WSL and the dotnet tool package appeared to build correctly in both systems.

I reviewed the contributor guidelines and did not see any other modifications I should make with this change, but if there is anything more I should do as a part of this fix, please let me know.