### PR TITLE
Upgrade all netcoreapp2.1  to netcoreapp3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN ./build/Extract-Resource.ps1 -File "$(find ~/.nuget/packages/mysql.data/ -na
 
 COPY . ./
 
-RUN dotnet publish -v q -nologo --no-restore product/roundhouse.console -o /app/out -p:TargetFramework=netcoreapp2.1 -p:Version="${VERSION}" -p:Configuration=Build -p:Platform="Any CPU"
+RUN dotnet publish -v q -nologo --no-restore product/roundhouse.console -o /app/out -p:TargetFramework=netcoreapp3.1 -p:Version="${VERSION}" -p:Configuration=Build -p:Platform="Any CPU"
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 

--- a/build.ps1
+++ b/build.ps1
@@ -54,13 +54,13 @@ dotnet pack -nologo --no-build -v q -p:Version="$($gitVersion.FullSemVer)" -p:No
 nuget pack product/roundhouse.console/roundhouse.nuspec -OutputDirectory "$CODEDROP/packages" -Verbosity quiet -NoPackageAnalysis -Version "$($gitVersion.FullSemVer)" 
 msbuild /t:"Pack" product/roundhouse.tasks/roundhouse.tasks.csproj  /p:DropFolder=$CODEDROP /p:Version="$($gitVersion.FullSemVer)" /p:NoPackageAnalysis=true /nologo /v:q /fl /flp:"LogFile=$LOGDIR/msbuild.roundhouse.tasks.pack.log;Verbosity=n" /p:Configuration=Build /p:Platform="Any CPU"
 
-"    - netcoreapp2.1 global tool dotnet-roundhouse"
+"    - netcoreapp3.1 global tool dotnet-roundhouse"
 
-dotnet publish -v q -nologo --no-restore product/roundhouse.console -p:NoPackageAnalysis=true -p:TargetFramework=netcoreapp2.1 -p:Version="$($gitVersion.FullSemVer)" -p:Configuration=Build -p:Platform="Any CPU"
-dotnet pack -v q -nologo --no-restore --no-build product/roundhouse.console -p:NoPackageAnalysis=true -p:TargetFramework=netcoreapp2.1 -o ${PACKAGEDIR} -p:Version="$($gitVersion.FullSemVer)" -p:Configuration=Build -p:Platform="Any CPU"
+dotnet publish -v q -nologo --no-restore product/roundhouse.console -p:NoPackageAnalysis=true -p:TargetFramework=netcoreapp3.1 -p:Version="$($gitVersion.FullSemVer)" -p:Configuration=Build -p:Platform="Any CPU"
+dotnet pack -v q -nologo --no-restore --no-build product/roundhouse.console -p:NoPackageAnalysis=true -p:TargetFramework=netcoreapp3.1 -o ${PACKAGEDIR} -p:Version="$($gitVersion.FullSemVer)" -p:Configuration=Build -p:Platform="Any CPU"
 
 
-# " * Packaging netcoreapp2.1 global tool dotnet-roundhouse`n"
+# " * Packaging netcoreapp3.1 global tool dotnet-roundhouse`n"
 
 # nuget pack -Verbosity quiet -outputdirectory ${PACKAGEDIR} .\product\roundhouse.console\roundhouse.tool.nuspec -Properties "Version=$($gitVersion.FullSemVer);NoPackageAnalysis=true"
 

--- a/product/roundhouse.console/roundhouse.console.csproj
+++ b/product/roundhouse.console/roundhouse.console.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFramework)' == ''">netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFramework)' == ''">netcoreapp3.1;net461</TargetFrameworks>
     <TargetFramework Condition="'$(TargetFramework)' == ''">net461</TargetFramework>
     <CLSCompliant>true</CLSCompliant>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -18,7 +18,7 @@
     <NugetVersion Condition="'$(NugetVersion)' == ''">$(Version)</NugetVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <NuspecFile>roundhouse.tool.nuspec</NuspecFile>
   </PropertyGroup>
 
@@ -45,8 +45,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.5.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
   </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
@@ -86,7 +89,7 @@
     </EmbeddedResource>
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <None Include="rh" CopyToOutputDirectory="PreserveNewest" />
     <None Include="rh.bat" CopyToOutputDirectory="PreserveNewest" />
     <None Include="DotnetToolSettings.xml" CopyToOutputDirectory="PreserveNewest" />
@@ -99,7 +102,7 @@
     <NuspecProperties>mergedExe=$(CopyDestination);version=$(NugetVersion)</NuspecProperties>
   </PropertyGroup>
     
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <NuspecFile>roundhouse.tool.nuspec</NuspecFile>
     <NuspecProperties>version=$(NugetVersion)</NuspecProperties>
   </PropertyGroup>

--- a/product/roundhouse.console/roundhouse.tool.nuspec
+++ b/product/roundhouse.console/roundhouse.tool.nuspec
@@ -16,12 +16,12 @@
       <packageType name="DotnetTool" />
     </packageTypes>
     <dependencies>
-      <group targetFramework=".NETCoreApp2.1" />
+      <group targetFramework=".netcoreapp3.1" />
     </dependencies>
     <icon>images/RoundhousE_Logo.NuGet.jpg</icon>
   </metadata>
   <files>
-    <file src="bin/netcoreapp2.1/publish/**/**" target="tools/netcoreapp2.1/any" />
+    <file src="bin/netcoreapp3.1/publish/**/**" target="tools/netcoreapp3.1/any" />
     <file src="../../nuget/RoundhousE_Logo.NuGet.jpg" target="images/" />
   </files>
 </package>

--- a/product/roundhouse.test.merged/roundhouse.test.merged.csproj
+++ b/product/roundhouse.test.merged/roundhouse.test.merged.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!--<TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>-->
+    <!--<TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>-->
     <TargetFramework>net461</TargetFramework>
     <CLSCompliant>true</CLSCompliant>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/product/roundhouse.tests/roundhouse.tests.csproj
+++ b/product/roundhouse.tests/roundhouse.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <CLSCompliant>true</CLSCompliant>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputType>Library</OutputType>

--- a/roundhouse.sln
+++ b/roundhouse.sln
@@ -49,8 +49,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "roundhouse.test.merged", "p
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "roundhouse.core", "product\roundhouse.core\roundhouse.core.csproj", "{328AA2A7-D213-46EB-861E-5D9CA94F8BFD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "roundhouse.console.tests", "product\roundhouse.console.tests\roundhouse.console.tests.csproj", "{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Build|Any CPU = Build|Any CPU
@@ -148,12 +146,6 @@ Global
 		{328AA2A7-D213-46EB-861E-5D9CA94F8BFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{328AA2A7-D213-46EB-861E-5D9CA94F8BFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{328AA2A7-D213-46EB-861E-5D9CA94F8BFD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}.Build|Any CPU.ActiveCfg = Debug|Any CPU
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}.Build|Any CPU.Build.0 = Debug|Any CPU
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -170,7 +162,6 @@ Global
 		{41CE538E-E6F1-4AB6-AB66-508DEF669A39} = {BCFAF88B-B6C0-48C1-B23E-FCC95B75588C}
 		{3447F080-CF50-4B02-9521-671E7AEE8D34} = {BCFAF88B-B6C0-48C1-B23E-FCC95B75588C}
 		{729625F9-E8E5-472B-BAA8-F7DEDACBD700} = {807C6B2C-496F-4A41-ABFE-EA5478EB9CFF}
-		{8A5A3D22-F391-4C5E-8540-B34D6C74A8D1} = {807C6B2C-496F-4A41-ABFE-EA5478EB9CFF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {54AD825C-DC48-4C69-88E5-356B43AC3674}


### PR DESCRIPTION
There are problems running RoundhousE on systems with only netcoreapp3.1 installed, as it is compiled against netcoreapp2.1. As 2.1 is in end-of-life, just upgrade to 3.1 all over