### PR TITLE
Fixed warnings with different versions of System.* nuget packages

### DIFF
--- a/product/roundhouse.console/roundhouse.console.csproj
+++ b/product/roundhouse.console/roundhouse.console.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/product/roundhouse.tests/roundhouse.tests.csproj
+++ b/product/roundhouse.tests/roundhouse.tests.csproj
@@ -32,6 +32,8 @@
     <PackageReference Include="System.Data.SQLite" Version="1.0.110" />
     <PackageReference Include="TinySpec.NUnit" Version="0.9.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Data.OracleClient" />


### PR DESCRIPTION
There were warnings on different versions (n-level dependencies) of System.Data and one other. Fixed by adding direct ref from client projects